### PR TITLE
Fixed many issues pointed out by cppcheck.

### DIFF
--- a/src/g_func.c
+++ b/src/g_func.c
@@ -573,15 +573,9 @@ void plat_blocked (edict_t *self, edict_t *other)
 		// give it a chance to go away on it's own terms (like gibs)
 		T_Damage (other, self, self, vec3_origin, other->s.origin, vec3_origin, 100000, 1, 0, MOD_CRUSH);
 		// if it's still there, nuke it
-		if (other)
-		{
-			/* Hack for entity without it's origin near the model */
-			vec3_t save;
-			VectorCopy(other->s.origin,save);
-			VectorMA (other->absmin, 0.5, other->size, other->s.origin);
-
-			BecomeExplosion1(other);
-		}
+		/* Hack for entity without it's origin near the model */
+		VectorMA (other->absmin, 0.5, other->size, other->s.origin);
+		BecomeExplosion1(other);
 
 		return;
 	}
@@ -1497,15 +1491,9 @@ void door_blocked  (edict_t *self, edict_t *other)
 		// give it a chance to go away on it's own terms (like gibs)
 		T_Damage (other, self, self, vec3_origin, other->s.origin, vec3_origin, 100000, 1, 0, MOD_CRUSH);
 		// if it's still there, nuke it
-		if (other)
-		{
-			/* Hack for entitiy without their origin near the model */
-			vec3_t save;
-			VectorCopy(other->s.origin,save);
-			VectorMA (other->absmin, 0.5, other->size, other->s.origin);
-
-			BecomeExplosion1(other);
-		}
+		/* Hack for entitiy without their origin near the model */
+		VectorMA (other->absmin, 0.5, other->size, other->s.origin);
+		BecomeExplosion1(other);
 
 		return;
 	}
@@ -1928,15 +1916,9 @@ void train_blocked (edict_t *self, edict_t *other)
 		// give it a chance to go away on it's own terms (like gibs)
 		T_Damage (other, self, self, vec3_origin, other->s.origin, vec3_origin, 100000, 1, 0, MOD_CRUSH);
 		// if it's still there, nuke it
-		if (other)
-		{
-			/* Hack for entity without an origin near the model */			
-			vec3_t save;
-			VectorCopy(other->s.origin,save);
-			VectorMA (other->absmin, 0.5, other->size, other->s.origin);
-
-			BecomeExplosion1(other);
-		}
+		/* Hack for entity without an origin near the model */
+		VectorMA (other->absmin, 0.5, other->size, other->s.origin);
+		BecomeExplosion1(other);
 
 		return;
 	}
@@ -2620,15 +2602,9 @@ void door_secret_blocked  (edict_t *self, edict_t *other)
 		// give it a chance to go away on it's own terms (like gibs)
 		T_Damage (other, self, self, vec3_origin, other->s.origin, vec3_origin, 100000, 1, 0, MOD_CRUSH);
 		// if it's still there, nuke it
-		if (other)
-		{
-			/* Hack for entities without their origin near the model */
-			vec3_t save;
-			VectorCopy(other->s.origin,save);
-			VectorMA (other->absmin, 0.5, other->size, other->s.origin);
-
-			BecomeExplosion1(other);
-		}
+		/* Hack for entities without their origin near the model */
+		VectorMA (other->absmin, 0.5, other->size, other->s.origin);
+		BecomeExplosion1(other);
 
 		return;
 	}

--- a/src/g_misc.c
+++ b/src/g_misc.c
@@ -153,11 +153,6 @@ void ThrowGib (edict_t *self, char *gibname, int damage, int type)
 	vec3_t	size;
 	float	vscale;
 
-	if (!self)
-	{
-		return;
-	}
-
 	if (!self || !gibname)
 	{
 		return;
@@ -333,11 +328,6 @@ void ThrowDebris (edict_t *self, char *modelname, float speed, vec3_t origin)
 {
 	edict_t	*chunk;
 	vec3_t	v;
-
-	if (!self)
-	{
-		return;
-	}
 
 	if (!self || !modelname)
 	{

--- a/src/g_phys.c
+++ b/src/g_phys.c
@@ -1102,7 +1102,7 @@ void SV_Physics_Step (edict_t *ent)
 
 void SV_Physics_FallFloat (edict_t *ent)
 {
-	float gravVal = ent->gravity * sv_gravity->value * FRAMETIME;
+	float gravVal;
 	qboolean wasonground = false;
 	qboolean hitsound = false;
 
@@ -1110,6 +1110,8 @@ void SV_Physics_FallFloat (edict_t *ent)
 	{
 		return;
 	}
+
+	gravVal = ent->gravity * sv_gravity->value * FRAMETIME;
 
 	// check velocity
 	SV_CheckVelocity (ent);

--- a/src/g_spawn.c
+++ b/src/g_spawn.c
@@ -311,11 +311,6 @@ void ED_CallSpawn (edict_t *ent)
 		return;
 	}
 
-	if (!ent)
-	{
-		return;
-	}
-
 	if (!ent->classname)
 	{
 		gi.dprintf ("ED_CallSpawn: NULL classname\n");
@@ -369,7 +364,7 @@ char *ED_NewString (const char *string)
 
 	for (i=0 ; i< l ; i++)
 	{
-		if (string[i] == '\\' && i < l-1)
+		if ((i < l-1) && (string[i] == '\\'))
 		{
 			i++;
 			if (string[i] == 'n')

--- a/src/g_utils.c
+++ b/src/g_utils.c
@@ -28,14 +28,14 @@ edict_t *G_Find (edict_t *from, int fieldofs, char *match)
 	char	*s;
 
 	if (!from)
-	{
-		return NULL;
-	}
-
-	if (!from)
 		from = g_edicts;
 	else
 		from++;
+
+	if (!match)
+	{
+		return NULL;
+	}
 
 	for ( ; from < &g_edicts[globals.num_edicts] ; from++)
 	{
@@ -67,14 +67,10 @@ edict_t *findradius (edict_t *from, vec3_t org, float rad)
 	int		j;
 
 	if (!from)
-	{
-		return NULL;
-	}
-
-	if (!from)
 		from = g_edicts;
 	else
 		from++;
+
 	for ( ; from < &g_edicts[globals.num_edicts]; from++)
 	{
 		if (!from->inuse)

--- a/src/header/shared.h
+++ b/src/header/shared.h
@@ -140,7 +140,7 @@ void AngleVectors(vec3_t angles, vec3_t forward, vec3_t right, vec3_t up);
 void AngleVectors2(vec3_t value1, vec3_t angles);
 int BoxOnPlaneSide(vec3_t emins, vec3_t emaxs, struct cplane_s *plane);
 float anglemod(float a);
-float LerpAngle(float a1, float a2, float frac);
+float LerpAngle(float a2, float a1, float frac);
 
 #define BOX_ON_PLANE_SIDE(emins, emaxs, p) \
 	(((p)->type < 3) ? \

--- a/src/monster/boss/boss.c
+++ b/src/monster/boss/boss.c
@@ -415,12 +415,14 @@ mmove_t zboss_move_pain3 = {FRAME_pain3Start, FRAME_pain3End, zboss_frames_pain3
 void zboss_pain (edict_t *self, edict_t *other, float kick, int damage)
 {
 	float r;
-	float hbreak = (self->max_health / 3.0);
+	float hbreak;
 
 	if (!self)
 	{
 		return;
 	}
+
+	hbreak = (self->max_health / 3.0);
 
 	// set the skin
 	if (self->health < hbreak)
@@ -742,14 +744,17 @@ void zboss_reelInGraaple2(edict_t *self)
 {
 	vec3_t	vec, dir;
 	float length;
-	edict_t *enemy = self->laser->enemy;
-	vec3_t	hookoffset	= {-5, -24, 34};
+	edict_t *enemy;
+	vec3_t	hookoffset;
 	vec3_t	forward, right;
 
 	if (!self)
 	{
 		return;
 	}
+
+	enemy = self->laser->enemy;
+	hookoffset	= {-5, -24, 34};
 
 	AngleVectors (self->s.angles, forward, right, NULL);
 	G_ProjectSource(self->s.origin, hookoffset, forward, right, vec);
@@ -1026,13 +1031,13 @@ mmove_t zboss_move_prehook = {FRAME_preHookStart, FRAME_preHookEnd, zboss_frames
 
 void PlasmaballBlastAnim(edict_t *ent)
 {
-	ent->s.frame++;
-	ent->s.skinnum++;
-
 	if (!ent)
 	{
 		return;
 	}
+
+	ent->s.frame++;
+	ent->s.skinnum++;
 
 	if(ent->s.frame > 1)
 	{

--- a/src/monster/misc/move.c
+++ b/src/monster/misc/move.c
@@ -439,10 +439,6 @@ void SV_NewChaseDir (edict_t *actor, edict_t *enemy, float dist)
 		return;
 	}
 
-	//FIXME: how did we get here with no enemy
-	if (!enemy)
-		return;
-
 	olddir = anglemod( (int)(actor->ideal_yaw/45)*45 );
 	turnaround = anglemod(olddir - 180);
 

--- a/src/player/client.c
+++ b/src/player/client.c
@@ -531,11 +531,11 @@ void LookAtKiller (edict_t *self, edict_t *inflictor, edict_t *attacker)
 		return;
 	}
 
-	if (attacker && attacker != world && attacker != self)
+	if (attacker != world && attacker != self)
 	{
 		VectorSubtract (attacker->s.origin, self->s.origin, dir);
 	}
-	else if (inflictor && inflictor != world && inflictor != self)
+	else if (inflictor != world && inflictor != self)
 	{
 		VectorSubtract (inflictor->s.origin, self->s.origin, dir);
 	}

--- a/src/player/view.c
+++ b/src/player/view.c
@@ -887,13 +887,13 @@ G_SetClientEvent
 */
 void G_SetClientEvent (edict_t *ent)
 {
-	if (ent->s.event)
-		return;
-
 	if (!ent)
 	{
 		return;
 	}
+
+	if (ent->s.event)
+		return;
 
 	if ( ent->groundentity && xyspeed > 225)
 	{

--- a/src/savegame/tables/gamefunc_decs.h
+++ b/src/savegame/tables/gamefunc_decs.h
@@ -304,7 +304,7 @@ extern void AddPointToBounds ( vec3_t v , vec3_t mins , vec3_t maxs ) ;
 extern void ClearBounds ( vec3_t mins , vec3_t maxs ) ;
 extern int BoxOnPlaneSide2 ( vec3_t emins , vec3_t emaxs , struct cplane_s * p ) ;
 extern float anglemod ( float a ) ;
-extern float LerpAngle ( float a2 , float a1 , float frac ) ;
+extern float LerpAngle ( float a1 , float a2 , float frac ) ;
 extern float Q_fabs ( float f ) ;
 extern void R_ConcatTransforms ( float in1 [ 3 ] [ 4 ] , float in2 [ 3 ] [ 4 ] , float out [ 3 ] [ 4 ] ) ;
 extern void R_ConcatRotations ( float in1 [ 3 ] [ 3 ] , float in2 [ 3 ] [ 3 ] , float out [ 3 ] [ 3 ] ) ;

--- a/src/savegame/tables/gamefunc_decs.h
+++ b/src/savegame/tables/gamefunc_decs.h
@@ -304,7 +304,7 @@ extern void AddPointToBounds ( vec3_t v , vec3_t mins , vec3_t maxs ) ;
 extern void ClearBounds ( vec3_t mins , vec3_t maxs ) ;
 extern int BoxOnPlaneSide2 ( vec3_t emins , vec3_t emaxs , struct cplane_s * p ) ;
 extern float anglemod ( float a ) ;
-extern float LerpAngle ( float a1 , float a2 , float frac ) ;
+extern float LerpAngle(float a2, float a1, float frac);
 extern float Q_fabs ( float f ) ;
 extern void R_ConcatTransforms ( float in1 [ 3 ] [ 4 ] , float in2 [ 3 ] [ 4 ] , float out [ 3 ] [ 4 ] ) ;
 extern void R_ConcatRotations ( float in1 [ 3 ] [ 3 ] , float in2 [ 3 ] [ 3 ] , float out [ 3 ] [ 3 ] ) ;

--- a/src/shared/shared.c
+++ b/src/shared/shared.c
@@ -1157,7 +1157,7 @@ Info_ValueForKey(char *s, char *key)
 
 		o = value[valueindex];
 
-		while (*s != '\\' && *s)
+		while (*s != '\\')
 		{
 			if (!*s)
 			{
@@ -1222,7 +1222,7 @@ Info_RemoveKey(char *s, char *key)
 
 		o = value;
 
-		while (*s != '\\' && *s)
+		while (*s != '\\')
 		{
 			if (!*s)
 			{
@@ -1274,6 +1274,11 @@ Info_SetValueForKey(char *s, char *key, char *value)
 	int c;
 	int maxsize = MAX_INFO_STRING;
 
+	if (!value || !strlen(value))
+	{
+		return;
+	}
+
 	if (strstr(key, "\\") || strstr(value, "\\"))
 	{
 		Com_Printf("Can't use keys or values with a \\\n");
@@ -1299,11 +1304,6 @@ Info_SetValueForKey(char *s, char *key, char *value)
 	}
 
 	Info_RemoveKey(s, key);
-
-	if (!value || !strlen(value))
-	{
-		return;
-	}
 
 	Com_sprintf(newi, sizeof(newi), "\\%s\\%s", key, value);
 

--- a/src/zaero/acannon.c
+++ b/src/zaero/acannon.c
@@ -426,12 +426,13 @@ void monster_autocannon_findenemy(edict_t *self)
 void monster_autocannon_turn(edict_t *self)
 {
 	vec3_t old_angles;
-	VectorCopy(self->s.angles, old_angles);
 
 	if (!self)
 	{
 		return;
 	}
+
+	VectorCopy(self->s.angles, old_angles);
 
 	if (!self->enemy)
 	{

--- a/src/zaero/ai.c
+++ b/src/zaero/ai.c
@@ -102,12 +102,14 @@ int zFindRoamYaw(edict_t *self, float distcheck)
 {
 	vec3_t	forward, end, angles;
 	trace_t	tr;
-	float current = anglemod(self->s.angles[YAW]);
+	float current;
 
 	if (!self)
 	{
 		return 0;
 	}
+
+	current = anglemod(self->s.angles[YAW]);
 
 	if(current <= self->ideal_yaw - 1 || current > self->ideal_yaw + 1)
 	{


### PR DESCRIPTION
Fixed the following issues found by cppcheck:

```
[src\g_func.c:576] (warning) Either the condition 'if(other)' is redundant or there is possible null pointer dereference: other. [nullPointerRedundantCheck]

[src\g_func.c:1500] (warning) Either the condition 'if(other)' is redundant or there is possible null pointer dereference: other. [nullPointerRedundantCheck]

[src\g_func.c:1931] (warning) Either the condition 'if(other)' is redundant or there is possible null pointer dereference: other. [nullPointerRedundantCheck]

[src\g_func.c:2623] (warning) Either the condition 'if(other)' is redundant or there is possible null pointer dereference: other. [nullPointerRedundantCheck]

[src\g_misc.c:156] (warning) Identical condition '!self', second condition is always false [identicalConditionAfterEarlyExit]

[src\g_misc.c:337] (warning) Identical condition '!self', second condition is always false [identicalConditionAfterEarlyExit]

[src\g_phys.c:1109] (warning) Either the condition '!ent' is redundant or there is possible null pointer dereference: ent. [nullPointerRedundantCheck]

[src\g_spawn.c:372] (style) Defensive programming: The variable 'i' is used as an array index before it is checked that is within limits. This can mean that the array might be accessed out of bounds. Reorder conditions such as '(a[i] && i < 10)' to '(i < 10 && a[i])'. That way the array will not be accessed if the index is out of limits. [arrayIndexThenCheck]

[src\g_spawn.c:309] (warning) Identical condition '!ent', second condition is always false [identicalConditionAfterEarlyExit]

[src\g_utils.c:30] (warning) Identical condition '!from', second condition is always false [identicalConditionAfterEarlyExit]

[src\g_utils.c:69] (warning) Identical condition '!from', second condition is always false [identicalConditionAfterEarlyExit]

[src\monster\boss\boss.c:420] (warning) Either the condition '!self' is redundant or there is possible null pointer dereference: self. [nullPointerRedundantCheck]

[src\monster\boss\boss.c:749] (warning) Either the condition '!self' is redundant or there is possible null pointer dereference: self. [nullPointerRedundantCheck]

[src\monster\boss\boss.c:1032] (warning) Either the condition '!ent' is redundant or there is possible null pointer dereference: ent. [nullPointerRedundantCheck]

[src\monster\misc\move.c:437] (style) Condition '!enemy' is always false [knownConditionTrueFalse]

[src\player\client.c:529] (style) Condition 'attacker' is always true [knownConditionTrueFalse]

[src\player\client.c:529] (style) Condition 'inflictor' is always true [knownConditionTrueFalse]

[src\player\view.c:893] (warning) Either the condition '!ent' is redundant or there is possible null pointer dereference: ent. [nullPointerRedundantCheck]

[src\shared\shared.c:1160] (warning) Opposite inner 'if' condition leads to a dead code block (outer condition is '*s' and inner condition is '!*s'). [oppositeInnerCondition]

[src\shared\shared.c:1225] (warning) Opposite inner 'if' condition leads to a dead code block (outer condition is '*s' and inner condition is '!*s'). [oppositeInnerCondition]

[src\shared\shared.c:1303] (warning) Either the condition '!value' is redundant or there is possible null pointer dereference: value. [nullPointerRedundantCheck]

[src\zaero\acannon.c:431] (warning) Either the condition '!self' is redundant or there is possible null pointer dereference: self. [nullPointerRedundantCheck]

[src\zaero\ai.c:107] (warning) Either the condition '!self' is redundant or there is possible null pointer dereference: self. [nullPointerRedundantCheck]
```

Only these are missing, I haven't figured out what should I do:
```
[src\monster\misc\move.c:650] (style) Condition 'rand()&(7==1)' is always false [knownConditionTrueFalse]

[src\zaero\mtest.c:506] (error) Resource leak: wCfgFile [resourceLeak]
```