### PR TITLE
Implement accurate-aiming CVAR in zaero game code.

### DIFF
--- a/src/g_main.c
+++ b/src/g_main.c
@@ -45,6 +45,7 @@ cvar_t  *gamedir;
 
 cvar_t	*sv_cheats;
 
+cvar_t *aimfix;
 
 void SpawnEntities (char *mapname, char *entities, char *spawnpoint);
 void ClientThink (edict_t *ent, usercmd_t *cmd);

--- a/src/header/local.h
+++ b/src/header/local.h
@@ -609,6 +609,8 @@ extern	cvar_t	*grenadeammotype;
 extern	cvar_t	*grenadeammo;
 extern	cvar_t	*bettyammo;
 
+extern cvar_t *aimfix;
+
 #define world	(&g_edicts[0])
 
 // item spawnflags

--- a/src/player/weapon.c
+++ b/src/player/weapon.c
@@ -21,9 +21,11 @@ void playQuadSound(edict_t *ent)
 void weapon_grenade_fire (edict_t *ent, qboolean held);
 
 
-void P_ProjectSource (gclient_t *client, vec3_t point, vec3_t distance, vec3_t forward, vec3_t right, vec3_t result)
+void P_ProjectSource (edict_t *ent, vec3_t distance, vec3_t forward, vec3_t right, vec3_t result)
 {
-	vec3_t	_distance;
+	gclient_t *client = ent->client;
+	float     *point  = ent->s.origin;
+	vec3_t     _distance;
 
 	if (!client)
 	{
@@ -36,6 +38,21 @@ void P_ProjectSource (gclient_t *client, vec3_t point, vec3_t distance, vec3_t f
 	else if (client->pers.hand == CENTER_HANDED)
 		_distance[1] = 0;
 	G_ProjectSource (point, _distance, forward, right, result);
+
+	// Berserker: fix - now the projectile hits exactly where the scope is pointing.
+	if (aimfix->value)
+	{
+		vec3_t start, end;
+		VectorSet(start, ent->s.origin[0], ent->s.origin[1], ent->s.origin[2] + ent->viewheight);
+		VectorMA(start, 8192, forward, end);
+
+		trace_t	tr = gi.trace(start, NULL, NULL, end, ent, MASK_SHOT);
+		if (tr.fraction < 1)
+		{
+			VectorSubtract(tr.endpos, result, forward);
+			VectorNormalize(forward);
+		}
+	}
 }
 
 
@@ -573,7 +590,7 @@ void weapon_grenade_fire (edict_t *ent, qboolean held)
 
 	VectorSet(offset, 8, 8, ent->viewheight-8);
 	AngleVectors (ent->client->v_angle, forward, right, NULL);
-	P_ProjectSource (ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource (ent, offset, forward, right, start);
 
 	timer = ent->client->grenade_time - level.time;
 	speed = GRENADE_MINSPEED + (GRENADE_TIMER - timer) * ((GRENADE_MAXSPEED - GRENADE_MINSPEED) / GRENADE_TIMER);
@@ -735,7 +752,7 @@ void weapon_grenadelauncher_fire (edict_t *ent)
 
 	VectorSet(offset, 8, 8, ent->viewheight-8);
 	AngleVectors (ent->client->v_angle, forward, right, NULL);
-	P_ProjectSource (ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource (ent, offset, forward, right, start);
 
 	VectorScale (forward, -2, ent->client->kick_origin);
 	ent->client->kick_angles[0] = -1;
@@ -808,7 +825,7 @@ void Weapon_RocketLauncher_Fire (edict_t *ent)
 	ent->client->kick_angles[0] = -1;
 
 	VectorSet(offset, 8, 8, ent->viewheight-8);
-	P_ProjectSource (ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource (ent, offset, forward, right, start);
 
 	if(EMPNukeCheck(ent, start))
 	{
@@ -873,7 +890,7 @@ int Blaster_Fire (edict_t *ent, vec3_t g_offset, int damage, qboolean hyper, int
 	AngleVectors (ent->client->v_angle, forward, right, NULL);
 	VectorSet(offset, 24, 8, ent->viewheight-8);
 	VectorAdd (offset, g_offset, offset);
-	P_ProjectSource (ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource (ent, offset, forward, right, start);
 
 	VectorScale (forward, -2, ent->client->kick_origin);
 	ent->client->kick_angles[0] = -1;
@@ -1088,7 +1105,7 @@ void Machinegun_Fire (edict_t *ent)
 	VectorAdd (ent->client->v_angle, ent->client->kick_angles, angles);
 	AngleVectors (angles, forward, right, NULL);
 	VectorSet(offset, 0, 8, ent->viewheight-8);
-	P_ProjectSource (ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource (ent, offset, forward, right, start);
 	fire_bullet (ent, start, forward, damage, kick, DEFAULT_BULLET_HSPREAD, DEFAULT_BULLET_VSPREAD, MOD_MACHINEGUN);
 
 	gi.WriteByte (svc_muzzleflash);
@@ -1222,7 +1239,7 @@ void Chaingun_Fire (edict_t *ent)
 		r = 7 + crandom()*4;
 		u = crandom()*4;
 		VectorSet(offset, 0, r, u + ent->viewheight-8);
-		P_ProjectSource (ent->client, ent->s.origin, offset, forward, right, start);
+		P_ProjectSource (ent, offset, forward, right, start);
 
 		fire_bullet (ent, start, forward, damage, kick, DEFAULT_BULLET_HSPREAD, DEFAULT_BULLET_VSPREAD, MOD_CHAINGUN);
 	}
@@ -1287,7 +1304,7 @@ void weapon_shotgun_fire (edict_t *ent)
 	ent->client->kick_angles[0] = -2;
 
 	VectorSet(offset, 0, 8,  ent->viewheight-8);
-	P_ProjectSource (ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource (ent, offset, forward, right, start);
 
 	if (is_quad)
 	{
@@ -1350,7 +1367,7 @@ void weapon_supershotgun_fire (edict_t *ent)
 	ent->client->kick_angles[0] = -2;
 
 	VectorSet(offset, 0, 8,  ent->viewheight-8);
-	P_ProjectSource (ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource (ent, offset, forward, right, start);
 
 	if (is_quad)
 	{
@@ -1442,7 +1459,7 @@ void weapon_railgun_fire (edict_t *ent)
 	ent->client->kick_angles[0] = -3;
 
 	VectorSet(offset, 0, 7,  ent->viewheight-8);
-	P_ProjectSource (ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource (ent, offset, forward, right, start);
 
 	ent->client->ps.gunframe++;
 
@@ -1508,7 +1525,7 @@ void weapon_bfg_fire (edict_t *ent)
 	VectorScale (forward, -2, ent->client->kick_origin);
 
 	VectorSet(offset, 8, 8, ent->viewheight-8);
-	P_ProjectSource (ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource (ent, offset, forward, right, start);
 
 	if(ent->client->ps.gunframe == 9)
 	{

--- a/src/savegame/savegame.c
+++ b/src/savegame/savegame.c
@@ -225,6 +225,9 @@ InitGame(void)
 	bob_pitch = gi.cvar ("bob_pitch", "0.002", 0);
 	bob_roll = gi.cvar ("bob_roll", "0.002", 0);
 
+	/* others */
+	aimfix = gi.cvar("aimfix", "0", CVAR_ARCHIVE);
+
 	/* items */
 	InitItems ();
 

--- a/src/savegame/tables/gamefunc_decs.h
+++ b/src/savegame/tables/gamefunc_decs.h
@@ -344,7 +344,7 @@ extern void NoAmmoWeaponChange ( edict_t * ent ) ;
 extern void ChangeWeapon ( edict_t * ent ) ;
 extern qboolean Pickup_Weapon ( edict_t * ent , edict_t * other ) ;
 extern void PlayerNoise ( edict_t * who , vec3_t where , int type ) ;
-extern void P_ProjectSource ( gclient_t * client , vec3_t point , vec3_t distance , vec3_t forward , vec3_t right , vec3_t result ) ;
+extern void P_ProjectSource ( edict_t * ent , vec3_t distance , vec3_t forward , vec3_t right , vec3_t result ) ;
 extern void playQuadSound ( edict_t * ent ) ;
 extern void ClientEndServerFrame ( edict_t * ent ) ;
 extern void G_SetClientFrame ( edict_t * ent ) ;

--- a/src/zaero/item.c
+++ b/src/zaero/item.c
@@ -16,7 +16,7 @@ void NoAmmoWeaponChange (edict_t *ent);
 void check_dodge (edict_t *self, vec3_t start, vec3_t dir, int speed);
 
 void Grenade_Explode(edict_t *ent);
-void P_ProjectSource (gclient_t *client, vec3_t point, vec3_t distance, vec3_t forward, vec3_t right, vec3_t result);
+void P_ProjectSource (edict_t *ent, vec3_t distance, vec3_t forward, vec3_t right, vec3_t result);
 
 void zCam_TrackEntity(struct edict_s *player, struct edict_s *track, qboolean playerVisiable, qboolean playerOffset);
 void zCam_Stop(struct edict_s *player);

--- a/src/zaero/mtest.c
+++ b/src/zaero/mtest.c
@@ -10,7 +10,7 @@ void Weapon_Generic (edict_t *ent,
 					 int *pause_frames, 
 					 int *fire_frames, 
 					 void (*fire)(edict_t *ent));
-void P_ProjectSource (gclient_t *client, vec3_t point, vec3_t distance, vec3_t forward, vec3_t right, vec3_t result);
+void P_ProjectSource (edict_t *ent, vec3_t distance, vec3_t forward, vec3_t right, vec3_t result);
 
 static char testItem_className[256];
 static char testItem_gModel[256];
@@ -56,7 +56,7 @@ void Weapon_LineDraw_Fire (edict_t *ent)
 	AngleVectors (ent->client->v_angle, forward, right, NULL);
 
 	VectorSet(offset, 0, 7,  ent->viewheight - 8);
-	P_ProjectSource (ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource (ent, offset, forward, right, start);
 
 	if(!ent->client->lineDraw)
 	{

--- a/src/zaero/weapon.c
+++ b/src/zaero/weapon.c
@@ -17,7 +17,7 @@ void NoAmmoWeaponChange (edict_t *ent);
 void check_dodge (edict_t *self, vec3_t start, vec3_t dir, int speed);
 
 void Grenade_Explode(edict_t *ent);
-void P_ProjectSource (gclient_t *client, vec3_t point, vec3_t distance, vec3_t forward, vec3_t right, vec3_t result);
+void P_ProjectSource (edict_t *ent, vec3_t distance, vec3_t forward, vec3_t right, vec3_t result);
 
 void fire_sconnan (edict_t *self);
 void fire_sconnanEffects (edict_t *self);
@@ -867,7 +867,7 @@ void fire_sconnanEffects (edict_t *self)
 	self->client->kick_angles[0] = -3;
 
 	VectorSet(offset, 0, 7,  self->viewheight-8);
-	P_ProjectSource (self->client, self->s.origin, offset, forward, right, start);
+	P_ProjectSource (self, offset, forward, right, start);
 
 	VectorMA (start, 8192, forward, end);
 
@@ -918,7 +918,7 @@ void fire_sconnan (edict_t *self)
 	self->client->kick_angles[0] = -3;
 
 	VectorSet(offset, 0, 7,  self->viewheight-8);
-	P_ProjectSource (self->client, self->s.origin, offset, forward, right, start);
+	P_ProjectSource (self, offset, forward, right, start);
 
 	VectorMA (start, 8192, forward, end);
 
@@ -1126,7 +1126,7 @@ void Weapon_FlareLauncher_Fire (edict_t *ent)
 	AngleVectors (ent->client->v_angle, forward, right, NULL);
 
 	VectorSet(offset, 8, 8, ent->viewheight-8);
-	P_ProjectSource (ent->client, ent->s.origin, offset, forward, right, start);
+	P_ProjectSource (ent, offset, forward, right, start);
 	fire_flare(ent, start, forward, 1, 600, 1, 1);
 
 	ent->client->ps.gunframe++;


### PR DESCRIPTION
Zaero-specific implementation of the changes in baseq2 PR [#561](https://github.com/yquake2/yquake2/pull/561).

This has been successfully build locally with GCC 9.3.0 but not gameplay tested as I don't have the PAK file(s) on-hand.