### PR TITLE
Fix compiler warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /build/
+/release/

--- a/src/g_items.c
+++ b/src/g_items.c
@@ -627,7 +627,7 @@ qboolean Pickup_Ammo (edict_t *ent, edict_t *other)
 		count = ent->item->quantity;
 
 	oldcount = other->client->pers.inventory[ITEM_INDEX(ent->item)];
-  
+
 	if(ent->spawnflags & 0x08)
 	{
 		if(oldcount >= count)
@@ -1066,7 +1066,7 @@ void Touch_Item (edict_t *ent, edict_t *other, cplane_t *plane, csurface_t *surf
 	if (taken)
 	{
 		// flash the screen
-		other->client->bonus_alpha = 0.25;	
+		other->client->bonus_alpha = 0.25;
 
 		// show icon and name on status bar
 		other->client->ps.stats[STAT_PICKUP_ICON] = gi.imageindex(ent->item->icon);
@@ -1150,7 +1150,7 @@ edict_t *Drop_Item (edict_t *ent, gitem_t *item)
 	VectorSet (dropped->maxs, 15, 15, 15);
 	gi.setmodel (dropped, dropped->item->world_model);
 	dropped->solid = SOLID_TRIGGER;
-	dropped->movetype = MOVETYPE_TOSS;  
+	dropped->movetype = MOVETYPE_TOSS;
 	dropped->touch = drop_temp_touch;
 	dropped->owner = ent;
 
@@ -1234,7 +1234,7 @@ void droptofloor (edict_t *ent)
 	else
 		gi.setmodel (ent, ent->item->world_model);
 	ent->solid = SOLID_TRIGGER;
-	ent->movetype = MOVETYPE_TOSS;  
+	ent->movetype = MOVETYPE_TOSS;
 	ent->touch = Touch_Item;
 
 	v = tv(0,0,-128);
@@ -1439,7 +1439,7 @@ void SpawnItem (edict_t *ent, gitem_t *item)
 
 //======================================================================
 
-gitem_t	itemlist[] = 
+gitem_t	itemlist[] =
 {
 	{
 		NULL
@@ -1452,7 +1452,7 @@ gitem_t	itemlist[] =
 /*QUAKED item_armor_body (.3 .3 1) (-16 -16 -16) (16 16 16)
 */
 	{
-		"item_armor_body", 
+		"item_armor_body",
 		Pickup_Armor,
 		NULL,
 		NULL,
@@ -1474,7 +1474,7 @@ gitem_t	itemlist[] =
 /*QUAKED item_armor_combat (.3 .3 1) (-16 -16 -16) (16 16 16)
 */
 	{
-		"item_armor_combat", 
+		"item_armor_combat",
 		Pickup_Armor,
 		NULL,
 		NULL,
@@ -1496,7 +1496,7 @@ gitem_t	itemlist[] =
 /*QUAKED item_armor_jacket (.3 .3 1) (-16 -16 -16) (16 16 16)
 */
 	{
-		"item_armor_jacket", 
+		"item_armor_jacket",
 		Pickup_Armor,
 		NULL,
 		NULL,
@@ -1518,7 +1518,7 @@ gitem_t	itemlist[] =
 /*QUAKED item_armor_shard (.3 .3 1) (-16 -16 -16) (16 16 16)
 */
 	{
-		"item_armor_shard", 
+		"item_armor_shard",
 		Pickup_Armor,
 		NULL,
 		NULL,
@@ -1541,7 +1541,7 @@ gitem_t	itemlist[] =
 /*QUAKED item_power_screen (.3 .3 1) (-16 -16 -16) (16 16 16)
 */
 	{
-		"item_power_screen", 
+		"item_power_screen",
 		Pickup_PowerArmor,
 		Use_PowerArmor,
 		Drop_PowerArmor,
@@ -1583,7 +1583,7 @@ gitem_t	itemlist[] =
 	},
 
 	//
-	// WEAPONS 
+	// WEAPONS
 	//
 
 /*QUAKED weapon_hand (.3 .3 1) (-16 -16 -16) (16 16 16)
@@ -1635,7 +1635,7 @@ gitem_t	itemlist[] =
 always owned, never in the world
 */
 	{
-		"weapon_blaster", 
+		"weapon_blaster",
 		NULL,
 		Use_Weapon,
 		NULL,
@@ -1657,7 +1657,7 @@ always owned, never in the world
 /*QUAKED weapon_shotgun (.3 .3 1) (-16 -16 -16) (16 16 16)
 */
 	{
-		"weapon_shotgun", 
+		"weapon_shotgun",
 		Pickup_Weapon,
 		Use_Weapon,
 		Drop_Weapon,
@@ -1679,7 +1679,7 @@ always owned, never in the world
 /*QUAKED weapon_supershotgun (.3 .3 1) (-16 -16 -16) (16 16 16)
 */
 	{
-		"weapon_supershotgun", 
+		"weapon_supershotgun",
 		Pickup_Weapon,
 		Use_Weapon,
 		Drop_Weapon,
@@ -1701,7 +1701,7 @@ always owned, never in the world
 /*QUAKED weapon_machinegun (.3 .3 1) (-16 -16 -16) (16 16 16)
 */
 	{
-		"weapon_machinegun", 
+		"weapon_machinegun",
 		Pickup_Weapon,
 		Use_Weapon,
 		Drop_Weapon,
@@ -1723,7 +1723,7 @@ always owned, never in the world
 /*QUAKED weapon_chaingun (.3 .3 1) (-16 -16 -16) (16 16 16)
 */
 	{
-		"weapon_chaingun", 
+		"weapon_chaingun",
 		Pickup_Weapon,
 		Use_Weapon,
 		Drop_Weapon,
@@ -1841,7 +1841,7 @@ always owned, never in the world
 /*QUAKED weapon_hyperblaster (.3 .3 1) (-16 -16 -16) (16 16 16)
 */
 	{
-		"weapon_hyperblaster", 
+		"weapon_hyperblaster",
 		Pickup_Weapon,
 		Use_Weapon,
 		Drop_Weapon,
@@ -1863,7 +1863,7 @@ always owned, never in the world
 /*QUAKED weapon_railgun (.3 .3 1) (-16 -16 -16) (16 16 16)
 */
 	{
-		"weapon_railgun", 
+		"weapon_railgun",
 		Pickup_Weapon,
 		Use_Weapon,
 		Drop_Weapon,
@@ -1885,7 +1885,7 @@ always owned, never in the world
 /*QUAKED weapon_sniperrifle (.3 .3 1) (-16 -16 -16) (16 16 16)
 */
 	{
-		"weapon_sniperrifle", 
+		"weapon_sniperrifle",
 		Pickup_Weapon,
 		Use_Weapon,
 		Drop_Weapon,
@@ -1951,7 +1951,7 @@ always owned, never in the world
 		IT_WEAPON|IT_STAY_COOP,
 		NULL,
 		0,
-/* precache */ "weapons/sonic/sc_warm.wav weapons/sonic/sc_cool.wav weapons/sonic/sc_fire.wav" // weapons/sonic/sc_act.wav weapons/sonic/sc_dact.wav  
+/* precache */ "weapons/sonic/sc_warm.wav weapons/sonic/sc_cool.wav weapons/sonic/sc_fire.wav" // weapons/sonic/sc_act.wav weapons/sonic/sc_dact.wav
 	},
 
 /*QUAKED ammo_a2k (.3 .3 1) (-16 -16 -16) (16 16 16)
@@ -1977,7 +1977,7 @@ always owned, never in the world
 		HIDE_FROM_SELECTION
 	},
 
-  
+
   //
 	// AMMO ITEMS
 	//
@@ -2137,7 +2137,7 @@ always owned, never in the world
 		IT_AMMO,
 		NULL,
 		AMMO_EMPNUKE,
-/* precache */ "items/empnuke/emp_trg.wav"  //items/empnuke/emp_act.wav items/empnuke/emp_spin.wav items/empnuke/emp_idle.wav 
+/* precache */ "items/empnuke/emp_trg.wav"  //items/empnuke/emp_act.wav items/empnuke/emp_spin.wav items/empnuke/emp_idle.wav
 	},
 
 	//
@@ -2146,7 +2146,7 @@ always owned, never in the world
 /*QUAKED item_quad (.3 .3 1) (-16 -16 -16) (16 16 16)
 */
 	{
-		"item_quad", 
+		"item_quad",
 		Pickup_Powerup,
 		Use_Quad,
 		Drop_General,
@@ -2275,7 +2275,7 @@ always owned, never in the world
 /* precache */ "items/visor/act.wav items/visor/deact.wav"// items/visor/next.wav"
 	},
 
-  
+
 /*QUAKED ammo_plasmashield (.3 .3 1) (-16 -16 -16) (16 16 16)
 */
 	{
@@ -2866,8 +2866,8 @@ void SetItemNames (void)
 {
 	int		i;
 	gitem_t	*it;
-	int index;
-	for (i=0, index = 0; i<game.num_items ; i++)
+
+	for (i=0; i<game.num_items ; i++)
 	{
 		it = &itemlist[i];
 		gi.configstring (CS_ITEMS+i, it->pickup_name);

--- a/src/g_phys.c
+++ b/src/g_phys.c
@@ -7,7 +7,7 @@
 
 pushmove objects do not obey gravity, and do not interact with each other or trigger fields, but block normal movement and push normal objects when they move.
 
-onground is set for toss objects when they come to a complete rest.  it is set for steping or walking objects 
+onground is set for toss objects when they come to a complete rest.  it is set for steping or walking objects
 
 doors, plats, etc are SOLID_BSP, and MOVETYPE_PUSH
 bonus items are SOLID_TRIGGER touch, and MOVETYPE_TOSS
@@ -334,10 +334,10 @@ void SV_AddGravity (edict_t *ent)
 }
 
 /*
- * Returns the actual bounding box of a bmodel. 
+ * Returns the actual bounding box of a bmodel.
  * This is a big improvement over what q2 normally
- * does with rotating bmodels - q2 sets absmin, 
- * absmax to a cube that will completely contain 
+ * does with rotating bmodels - q2 sets absmin,
+ * absmax to a cube that will completely contain
  * the bmodel at *any* rotation on *any* axis, whether
  * the bmodel can actually rotate to that angle or not.
  * This leads to a lot of false block tests in SV_Push
@@ -426,12 +426,12 @@ RealBoundingBox(edict_t *ent, vec3_t mins, vec3_t maxs)
 		if (mins[1] > p[i][1])
 		{
 			mins[1] = p[i][1];
-		}    
+		}
 
 		if (mins[2] > p[i][2])
 		{
 			mins[2] = p[i][2];
-		} 
+		}
 
 		if (maxs[0] < p[i][0])
 		{
@@ -532,7 +532,6 @@ qboolean SV_Push (edict_t *pusher, vec3_t move, vec3_t amove)
 {
 	int			i, e;
 	edict_t		*check, *block;
-	vec3_t		mins, maxs;
 	pushed_t	*p;
 	vec3_t		org, org2, move2, forward, right, up;
 	vec3_t		realmins, realmaxs;
@@ -555,13 +554,6 @@ qboolean SV_Push (edict_t *pusher, vec3_t move, vec3_t amove)
 		move[i] = 0.125 * (int)temp;
 	}
 
-	// find the bounding box
-	for (i=0 ; i<3 ; i++)
-	{
-		mins[i] = pusher->absmin[i] + move[i];
-		maxs[i] = pusher->absmax[i] + move[i];
-	}
-
 	// we need this for pushing things later
 	VectorSubtract (vec3_origin, amove, org);
 	AngleVectors (org, forward, right, up);
@@ -579,7 +571,7 @@ qboolean SV_Push (edict_t *pusher, vec3_t move, vec3_t amove)
 	VectorAdd (pusher->s.angles, amove, pusher->s.angles);
 	gi.linkentity (pusher);
 
-	/* Create a real bounding box for 
+	/* Create a real bounding box for
 	rotating brush models. */
 	RealBoundingBox(pusher,realmins,realmaxs);
 
@@ -624,7 +616,7 @@ qboolean SV_Push (edict_t *pusher, vec3_t move, vec3_t amove)
 			VectorCopy (check->s.angles, pushed_p->angles);
 			pushed_p++;
 
-			// try moving the contacted entity 
+			// try moving the contacted entity
 			VectorAdd (check->s.origin, move, check->s.origin);
 			if (check->client)
 			{	// FIXME: doesn't rotate monsters?
@@ -858,7 +850,7 @@ void SV_Physics_Toss (edict_t *ent)
 
 	// add gravity
 	if (ent->movetype != MOVETYPE_FLY
-		&& ent->movetype != MOVETYPE_FLYMISSILE 
+		&& ent->movetype != MOVETYPE_FLYMISSILE
 		&& ent->movetype != MOVETYPE_BOUNCEFLY)
 		SV_AddGravity (ent);
 

--- a/src/g_spawn.c
+++ b/src/g_spawn.c
@@ -279,7 +279,7 @@ spawn_t	spawns[] = {
 	{"monster_handler", SP_monster_handler},
 	{"misc_commdish", SP_misc_commdish},
 
-	// mirror level's 
+	// mirror level's
 	{"load_mirrorlevel", SP_load_mirrorlevel},
 
 	{"misc_crate", SP_misc_crate},
@@ -350,7 +350,7 @@ char *ED_NewString (const char *string)
 {
 	char	*newb, *new_p;
 	int		i,l;
-	
+
 	if (!string)
 	{
 		return NULL;
@@ -375,7 +375,7 @@ char *ED_NewString (const char *string)
 		else
 			*new_p++ = string[i];
 	}
-	
+
 	return newb;
 }
 
@@ -466,7 +466,7 @@ char *ED_ParseEdict (char *data, edict_t *ent)
 
 	// go through all the dictionary pairs
 	while (1)
-	{	
+	{
 		// parse key
 		com_token = COM_Parse (&data);
 		if (com_token[0] == '}')
@@ -475,8 +475,8 @@ char *ED_ParseEdict (char *data, edict_t *ent)
 			gi.error ("ED_ParseEntity: EOF without closing brace");
 
 		strncpy (keyname, com_token, sizeof(keyname)-1);
-		
-		// parse value	
+
+		// parse value
 		com_token = COM_Parse (&data);
 		if (!data)
 			gi.error ("ED_ParseEntity: EOF without closing brace");
@@ -484,7 +484,7 @@ char *ED_ParseEdict (char *data, edict_t *ent)
 		if (com_token[0] == '}')
 			gi.error ("ED_ParseEntity: closing brace without data");
 
-		init = true;	
+		init = true;
 
 		// keynames with a leading underscore are used for utility comments,
 		// and are immediately discarded by quake
@@ -572,7 +572,6 @@ void SpawnEntities (const char *mapname, char *entities, const char *spawnpoint)
 	const char	*com_token;
 	int			i;
 	float		skill_level;
-	int oldmaxent;
 
 	skill_level = floor (skill->value);
 	if (skill_level < 0)
@@ -602,7 +601,7 @@ void SpawnEntities (const char *mapname, char *entities, const char *spawnpoint)
 	// parse ents
 	while (1)
 	{
-		// parse the opening brace	
+		// parse the opening brace
 		com_token = COM_Parse (&entities);
 		if (!entities)
 			break;
@@ -627,7 +626,7 @@ void SpawnEntities (const char *mapname, char *entities, const char *spawnpoint)
 			{
 				if ( (ent->spawnflags & SPAWNFLAG_NOT_DEATHMATCH) || (ent->spawnflags2 & SPAWNFLAG2_NOT_SINGLE) )
 				{
-					G_FreeEdict (ent);	
+					G_FreeEdict (ent);
 					inhibit++;
 					continue;
 				}
@@ -667,7 +666,7 @@ void SpawnEntities (const char *mapname, char *entities, const char *spawnpoint)
 					(((skill->value == SKILL_HARD) || (skill->value == SKILL_HARDPLUS)) && (ent->spawnflags & SPAWNFLAG_NOT_HARD))
 					)
 					{
-						G_FreeEdict (ent);	
+						G_FreeEdict (ent);
 						inhibit++;
 						continue;
 					}
@@ -677,9 +676,7 @@ void SpawnEntities (const char *mapname, char *entities, const char *spawnpoint)
 		}
 
 		ED_CallSpawn (ent);
-	}	
-
-	oldmaxent = globals.num_edicts;
+	}
 
 	gi.dprintf("%i entities created\n", globals.num_edicts);
 	gi.dprintf ("%i entities inhibited\n", inhibit);
@@ -694,7 +691,7 @@ void SpawnEntities (const char *mapname, char *entities, const char *spawnpoint)
 
 //===================================================================
 
-char *single_statusbar = 
+char *single_statusbar =
 "yb	-24 "
 
 // health
@@ -745,7 +742,7 @@ char *single_statusbar =
 "	pic	9 "
 "endif "
 
-//  help / weapon icon 
+//  help / weapon icon
 "if 11 "
 "	xv	148 "
 "	pic	11 "
@@ -814,7 +811,7 @@ char *dm_statusbar =
 "	pic	9 "
 "endif "
 
-//  help / weapon icon 
+//  help / weapon icon
 "if 11 "
 "	xv	148 "
 "	pic	11 "
@@ -937,9 +934,9 @@ void SP_worldspawn (edict_t *ent)
 	gi.soundindex ("*death3.wav");
 	gi.soundindex ("*death4.wav");
 	gi.soundindex ("*fall1.wav");
-	gi.soundindex ("*fall2.wav");	
+	gi.soundindex ("*fall2.wav");
 	gi.soundindex ("*gurp1.wav");		// drowning damage
-	gi.soundindex ("*gurp2.wav");	
+	gi.soundindex ("*gurp2.wav");
 	gi.soundindex ("*jump1.wav");		// player jump
 	gi.soundindex ("*pain25_1.wav");
 	gi.soundindex ("*pain25_2.wav");
@@ -959,7 +956,7 @@ void SP_worldspawn (edict_t *ent)
 	gi.soundindex ("player/watr_out.wav");	// feet leaving water
 
 	gi.soundindex ("player/watr_un.wav");	// head going underwater
-	
+
 	gi.soundindex ("player/u_breath1.wav");
 	gi.soundindex ("player/u_breath2.wav");
 
@@ -988,40 +985,40 @@ void SP_worldspawn (edict_t *ent)
 
 	// 0 normal
 	gi.configstring(CS_LIGHTS+0, "m");
-	
+
 	// 1 FLICKER (first variety)
 	gi.configstring(CS_LIGHTS+1, "mmnmmommommnonmmonqnmmo");
-	
+
 	// 2 SLOW STRONG PULSE
 	gi.configstring(CS_LIGHTS+2, "abcdefghijklmnopqrstuvwxyzyxwvutsrqponmlkjihgfedcba");
-	
+
 	// 3 CANDLE (first variety)
 	gi.configstring(CS_LIGHTS+3, "mmmmmaaaaammmmmaaaaaabcdefgabcdefg");
-	
+
 	// 4 FAST STROBE
 	gi.configstring(CS_LIGHTS+4, "mamamamamama");
-	
+
 	// 5 GENTLE PULSE 1
 	gi.configstring(CS_LIGHTS+5,"jklmnopqrstuvwxyzyxwvutsrqponmlkj");
-	
+
 	// 6 FLICKER (second variety)
 	gi.configstring(CS_LIGHTS+6, "nmonqnmomnmomomno");
-	
+
 	// 7 CANDLE (second variety)
 	gi.configstring(CS_LIGHTS+7, "mmmaaaabcdefgmmmmaaaammmaamm");
-	
+
 	// 8 CANDLE (third variety)
 	gi.configstring(CS_LIGHTS+8, "mmmaaammmaaammmabcdefaaaammmmabcdefmmmaaaa");
-	
+
 	// 9 SLOW STROBE (fourth variety)
 	gi.configstring(CS_LIGHTS+9, "aaaaaaaazzzzzzzz");
-	
+
 	// 10 FLUORESCENT FLICKER
 	gi.configstring(CS_LIGHTS+10, "mmamammmmammamamaaamammma");
 
 	// 11 SLOW PULSE NOT FADE TO BLACK
 	gi.configstring(CS_LIGHTS+11, "abcdefghijklmnopqrrqponmlkjihgfedcba");
-	
+
 	// styles 32-62 are assigned by the light program for switchable lights
 
 	// 63 testing

--- a/src/g_target.c
+++ b/src/g_target.c
@@ -386,7 +386,7 @@ void use_target_changelevel (edict_t *self, edict_t *other, edict_t *activator)
 	}
 
 	// if going to a new unit, clear cross triggers
-	if (strstr(self->map, "*"))	
+	if (strstr(self->map, "*"))
 		game.serverflags &= ~(SFL_CROSS_TRIGGER_MASK);
 
 	BeginIntermission (self);
@@ -534,8 +534,6 @@ speed	default is 1000
 
 void use_target_blaster (edict_t *self, edict_t *other, edict_t *activator)
 {
-	int effect;
-
 	if (!self)
 	{
 		return;
@@ -546,13 +544,6 @@ void use_target_blaster (edict_t *self, edict_t *other, edict_t *activator)
 		gi.sound (self, CHAN_AUTO, gi.soundindex("items/empnuke/emp_missfire.wav"), 1, ATTN_NORM, 0);
 		return;
 	}
-
-	if (self->spawnflags & 2)
-		effect = 0;
-	else if (self->spawnflags & 1)
-		effect = EF_HYPERBLASTER;
-	else
-		effect = EF_BLASTER;
 
 	fire_blaster (self, self->s.origin, self->movedir, self->dmg, self->speed, EF_BLASTER, MOD_TARGET_BLASTER);
 	gi.sound (self, CHAN_VOICE, self->noise_index, 1, ATTN_NORM, 0);

--- a/src/g_turret.c
+++ b/src/g_turret.c
@@ -288,7 +288,7 @@ Must NOT be on the team with the rest of the turret parts.
 Instead it must target the turret_breach.
 */
 
-void infantry_die (edict_t *self, edict_t *inflictor, edict_t *attacker, int damage);
+void infantry_die (edict_t *self, edict_t *inflictor, edict_t *attacker, int damage, vec3_t point);
 void infantry_stand (edict_t *self);
 void monster_use (edict_t *self, edict_t *other, edict_t *activator);
 
@@ -314,7 +314,7 @@ void turret_driver_die (edict_t *self, edict_t *inflictor, edict_t *attacker, in
 	self->target_ent->owner = NULL;
 	self->target_ent->teammaster->owner = NULL;
 
-	infantry_die (self, inflictor, attacker, damage);
+	infantry_die (self, inflictor, attacker, damage, point);
 }
 
 qboolean FindTarget (edict_t *self);

--- a/src/monster/boss/boss.c
+++ b/src/monster/boss/boss.c
@@ -187,7 +187,7 @@ void zboss_standidle (edict_t *self)
   }
 }
 
-// 
+//
 // Post WALK/RUN leading into ilde.
 //
 
@@ -245,7 +245,7 @@ mframe_t zboss_frames_walk [] =
 	{ai_walk,  4, NULL},	// 170
 	{ai_walk,  4, NULL},
 	{ai_walk,  4, NULL},
-	{ai_walk,  3, NULL},	
+	{ai_walk,  3, NULL},
 	{ai_walk,  2, NULL},
 	{ai_walk,  2, NULL},
 	{ai_walk,  3, zboss_walksound},						// 176
@@ -302,7 +302,7 @@ mframe_t zboss_frames_run [] =
 	{ai_run,  4, NULL},	// 170
 	{ai_run,  4, NULL},
 	{ai_run,  4, NULL},
-	{ai_run,  3, NULL},	
+	{ai_run,  3, NULL},
 	{ai_run,  2, NULL},
 	{ai_run,  2, NULL},
 	{ai_run,  3, zboss_walksound},						// 176
@@ -345,9 +345,9 @@ void zboss_stand (edict_t *self)
 		return;
 	}
 
-	if(self->monsterinfo.currentmove == &zboss_move_prewalk || 
-				self->monsterinfo.currentmove == &zboss_move_walk || 
-				self->monsterinfo.currentmove == &zboss_move_prerun || 
+	if(self->monsterinfo.currentmove == &zboss_move_prewalk ||
+				self->monsterinfo.currentmove == &zboss_move_walk ||
+				self->monsterinfo.currentmove == &zboss_move_prerun ||
 				self->monsterinfo.currentmove == &zboss_move_run)
 	{
 		zboss_postWalkRun(self);
@@ -596,7 +596,7 @@ void zboss_melee (edict_t *self)
 mframe_t zboss_frames_attack1b [] =
 {
 	{ai_charge, 0,	NULL},	// 92
-	{ai_charge, 0,	NULL},		 
+	{ai_charge, 0,	NULL},
 	{ai_charge, 0,	NULL},
 	{ai_charge, 0,	NULL},
 	{ai_charge, 0,	NULL},
@@ -618,7 +618,7 @@ void zboss_reloadRockets(edict_t *self)
 }
 
 
-static vec3_t	rocketoffset[]	= 
+static vec3_t	rocketoffset[]	=
 {
 	{-5, -50, 33},
 	{-5, -39, 27},
@@ -659,7 +659,7 @@ void FireFlare(edict_t *self)
 
 	VectorSubtract (vec, start, dir);
 	VectorNormalize (dir);
-	
+
 	if(!(self->monsterinfo.aiflags & AI_ONESHOTTARGET))
 	{
 		ANIM_AIM(self, dir);
@@ -794,7 +794,7 @@ mmove_t zboss_move_attack2b = {FRAME_attack2bStart, FRAME_attack2bEnd, zboss_fra
 void HookDragThink (edict_t *self)
 {
 	vec3_t	dir, vec;
-	float length, speed;
+	float	speed;
 	vec3_t	hookoffset	= {-5, -24, 34};
 	vec3_t	forward, right;
 
@@ -809,7 +809,6 @@ void HookDragThink (edict_t *self)
 	}
 
 	VectorSubtract (self->owner->s.origin, self->s.origin, dir);
-	length = VectorLength (dir);
 
 	AngleVectors (self->owner->s.angles, forward, right, NULL);
 	G_ProjectSource(self->owner->s.origin, hookoffset, forward, right, vec);
@@ -918,11 +917,11 @@ void FireHook(edict_t *self)
 	vec[2] += self->enemy->viewheight;
 	VectorSubtract (vec, start, dir);
 	VectorNormalize (dir);
-	
+
   ANIM_AIM(self, dir);
 
 	self->s.modelindex3 = 0;
-	
+
 	speed = 1000;
 
 	gi.sound (self, CHAN_WEAPON, sound_hooklaunch, 1, ATTN_NORM, 0);
@@ -1149,7 +1148,7 @@ void fire_plasmaCannon (edict_t *self, vec3_t start, vec3_t aimdir, int damage, 
 }
 
 
-static vec3_t cannonoffset[]	= 
+static vec3_t cannonoffset[]	=
 {
 	{-19, -44, 30},
 	{-14, -33, 32},
@@ -1209,7 +1208,7 @@ void FireCannon(edict_t *self)
 	{
 		distance = 700;
 	}
-	
+
 	if(skill->value < SKILL_HARD)
 	{
 		fire_plasmaCannon (self, start, dir, 90, 700, 2.5, 90+40, distance);
@@ -1447,7 +1446,7 @@ void FireDeadRocket1(edict_t *self)
 	AngleVectors (self->s.angles, forward, right, NULL);
 
 	G_ProjectSource (self->s.origin, rocketoffset, forward, right, start);
-	
+
 	fire_rocket (self, start, forward, 70, 500, 70+20, 70);
 
 	gi.WriteByte (svc_muzzleflash2);
@@ -1470,7 +1469,7 @@ void FireDeadRocket2(edict_t *self)
 	AngleVectors (self->s.angles, forward, right, NULL);
 
 	G_ProjectSource (self->s.origin, rocketoffset, forward, right, start);
-	
+
 	forward[1] += 10;
 	fire_rocket (self, start, forward, 70, 500, 70+20, 70);
 
@@ -1494,7 +1493,7 @@ void FireDeadRocket3(edict_t *self)
 	AngleVectors (self->s.angles, forward, right, up);
 
 	G_ProjectSource (self->s.origin, rocketoffset, forward, right, start);
-	
+
 	fire_rocket (self, start, up, 70, 500, 70+20, 70);
 
 	gi.WriteByte (svc_muzzleflash2);
@@ -1517,7 +1516,7 @@ void FireDeadRocket4(edict_t *self)
 	AngleVectors (self->s.angles, forward, right, up);
 
 	G_ProjectSource (self->s.origin, rocketoffset, forward, right, start);
-	
+
 	fire_rocket (self, start, up, 70, 500, 70+20, 70);
 
 	gi.WriteByte (svc_muzzleflash2);
@@ -1614,7 +1613,7 @@ void FireDeadCannon1(edict_t *self)
 	AngleVectors (self->s.angles, forward, right, NULL);
 
 	G_ProjectSource (self->s.origin, cannonoffset, forward, right, start);
-	
+
 	fire_plasmaCannon (self, start, forward, 90, 700, 2.5, 90+40, 700);
 
 	gi.WriteByte (svc_muzzleflash2);
@@ -1637,7 +1636,7 @@ void FireDeadCannon2(edict_t *self)
 	AngleVectors (self->s.angles, forward, right, NULL);
 
 	G_ProjectSource (self->s.origin, cannonoffset, forward, right, start);
-	
+
 	fire_plasmaCannon (self, start, forward, 90, 700, 2.5, 90+40, 700);
 
 	gi.WriteByte (svc_muzzleflash2);
@@ -1660,7 +1659,7 @@ void FireDeadCannon3(edict_t *self)
 	AngleVectors (self->s.angles, forward, right, NULL);
 
 	G_ProjectSource (self->s.origin, cannonoffset, forward, right, start);
-	
+
 	fire_plasmaCannon (self, start, forward, 90, 700, 2.5, 90+40, 700);
 
 	gi.WriteByte (svc_muzzleflash2);
@@ -1707,9 +1706,9 @@ void FireDeadGrapple(edict_t *self)
 	AngleVectors (self->s.angles, forward, right, up);
 
 	G_ProjectSource (self->s.origin, hookoffset, forward, right, start);
-	
+
 	self->s.modelindex3 = 0;
-	
+
 	speed = 500;
 
 	gi.sound (self, CHAN_WEAPON, sound_hooklaunch, 1, ATTN_NORM, 0);
@@ -1762,9 +1761,9 @@ mframe_t zboss_frames_death2 [] =
 
 	{ai_move, 0,	FireDeadCannon1},  // 257
 	{ai_move, 0,	FireDeadCannon2},	// 258
-	{ai_move, 0,	NULL},	
 	{ai_move, 0,	NULL},
-	{ai_move, 0,	NULL},	
+	{ai_move, 0,	NULL},
+	{ai_move, 0,	NULL},
 	{ai_move, 0,	NULL},
 	{ai_move, 0,	NULL},
 	{ai_move, 0,	FireDeadCannon3},	// 264
@@ -1847,11 +1846,11 @@ End Death Stuff
 */
 void SP_monster_zboss_precache(void)
 {
-	sound_pain1 = gi.soundindex ("monsters/bossz/bpain1.wav");	
-	sound_pain2 = gi.soundindex ("monsters/bossz/bpain2.wav");	
-	sound_pain3 = gi.soundindex ("monsters/bossz/bpain3.wav");	
-	sound_die1 = gi.soundindex ("monsters/bossz/bdeth1.wav");	
-	sound_die2 = gi.soundindex ("monsters/bossz/bdeth2.wav");	
+	sound_pain1 = gi.soundindex ("monsters/bossz/bpain1.wav");
+	sound_pain2 = gi.soundindex ("monsters/bossz/bpain2.wav");
+	sound_pain3 = gi.soundindex ("monsters/bossz/bpain3.wav");
+	sound_die1 = gi.soundindex ("monsters/bossz/bdeth1.wav");
+	sound_die2 = gi.soundindex ("monsters/bossz/bdeth2.wav");
 	sound_hooklaunch = gi.soundindex("monsters/bossz/bhlaunch.wav");
 	sound_hookimpact = gi.soundindex("monsters/bossz/bhimpact.wav");
 	sound_hookfly	= gi.soundindex("monsters/bossz/bhfly.wav");
@@ -1936,13 +1935,13 @@ void SP_monster_zboss (edict_t *self)
 
 	gi.linkentity (self);
 
-	self->monsterinfo.currentmove = &zboss_stand1;	
+	self->monsterinfo.currentmove = &zboss_stand1;
 	self->monsterinfo.scale = MODEL_SCALE;
 
 	walkmonster_start (self);
 }
 
-/*QUAKED target_zboss_target 
+/*QUAKED target_zboss_target
 */
 
 void trigger_zboss (edict_t *self, edict_t *other, edict_t *activator)

--- a/src/monster/boss2/boss2.c
+++ b/src/monster/boss2/boss2.c
@@ -79,7 +79,7 @@ void Boss2Rocket (edict_t *self)
 	VectorSubtract (vec, start, dir);
 	VectorNormalize (dir);
 	monster_fire_rocket (self, start, dir, 50, 500, MZ2_BOSS2_ROCKET_4);
-}	
+}
 
 void boss2_firebullet_right (edict_t *self)
 {
@@ -106,7 +106,7 @@ void boss2_firebullet_right (edict_t *self)
 	}
 
 	monster_fire_bullet (self, start, forward, 6, 4, DEFAULT_BULLET_HSPREAD, DEFAULT_BULLET_VSPREAD, MZ2_BOSS2_MACHINEGUN_R1);
-}	
+}
 
 void boss2_firebullet_left (edict_t *self)
 {
@@ -134,7 +134,7 @@ void boss2_firebullet_left (edict_t *self)
 	}
 
 	monster_fire_bullet (self, start, forward, 6, 4, DEFAULT_BULLET_HSPREAD, DEFAULT_BULLET_VSPREAD, MZ2_BOSS2_MACHINEGUN_L1);
-}	
+}
 
 void Boss2MachineGun (edict_t *self)
 {
@@ -458,7 +458,7 @@ void boss2_attack (edict_t *self)
 	{
 		self->monsterinfo.currentmove = &boss2_move_attack_pre_mg;
 	}
-	else 
+	else
 	{
 		if (random() <= 0.6)
 			self->monsterinfo.currentmove = &boss2_move_attack_pre_mg;
@@ -519,7 +519,7 @@ void boss2_pain (edict_t *self, edict_t *other, float kick, int damage)
 		gi.sound (self, CHAN_VOICE, sound_pain1, 1, ATTN_NONE, 0);
 		self->monsterinfo.currentmove = &boss2_move_pain_light;
 	}
-	else 
+	else
 	{
 		gi.sound (self, CHAN_VOICE, sound_pain2, 1, ATTN_NONE, 0);
 		self->monsterinfo.currentmove = &boss2_move_pain_heavy;
@@ -561,7 +561,6 @@ qboolean Boss2_CheckAttack (edict_t *self)
 	vec3_t	temp;
 	float	chance;
 	trace_t	tr;
-	qboolean	enemy_infront;
 	int			enemy_range;
 	float		enemy_yaw;
 
@@ -584,8 +583,7 @@ qboolean Boss2_CheckAttack (edict_t *self)
 		if (tr.ent != self->enemy)
 			return false;
 	}
-	
-	enemy_infront = infront(self, self->enemy);
+
 	enemy_range = range(self, self->enemy);
 	VectorSubtract (self->enemy->s.origin, self->s.origin, temp);
 	enemy_yaw = vectoyaw(temp);
@@ -602,14 +600,14 @@ qboolean Boss2_CheckAttack (edict_t *self)
 			self->monsterinfo.attack_state = AS_MISSILE;
 		return true;
 	}
-	
+
 	// missile attack
 	if (!self->monsterinfo.attack)
 		return false;
-		
+
 	if (level.time < self->monsterinfo.attack_finished)
 		return false;
-		
+
 	if (enemy_range == RANGE_FAR)
 		return false;
 
@@ -700,7 +698,7 @@ void SP_monster_boss2 (edict_t *self)
 	self->monsterinfo.checkattack = Boss2_CheckAttack;
 	gi.linkentity (self);
 
-	self->monsterinfo.currentmove = &boss2_move_stand;	
+	self->monsterinfo.currentmove = &boss2_move_stand;
 	self->monsterinfo.scale = MODEL_SCALE;
 
 	flymonster_start (self);

--- a/src/monster/boss3/boss31.c
+++ b/src/monster/boss3/boss31.c
@@ -331,10 +331,10 @@ mframe_t jorg_frames_death1 [] =
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
-	{ai_move,	0,	NULL},			
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
-	{ai_move,	0,	NULL},			
+	{ai_move,	0,	NULL},
+	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},		// 30
@@ -351,10 +351,10 @@ mframe_t jorg_frames_death1 [] =
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
-	{ai_move,	0,	NULL},			
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
-	{ai_move,	0,	NULL},			
+	{ai_move,	0,	NULL},
+	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	MakronToss},
 	{ai_move,	0,	BossExplode}		// 50
@@ -369,7 +369,7 @@ mframe_t jorg_frames_attack2 []=
 	{ai_charge,	0,	NULL},
 	{ai_charge,	0,	NULL},
 	{ai_charge,	0,	NULL},
-	{ai_charge,	0,	jorgBFG},		
+	{ai_charge,	0,	jorgBFG},
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
@@ -425,12 +425,12 @@ void jorg_reattack1(edict_t *self)
 		else
 		{
 			self->s.sound = 0;
-			self->monsterinfo.currentmove = &jorg_move_end_attack1;	
+			self->monsterinfo.currentmove = &jorg_move_end_attack1;
 		}
 	else
 	{
 		self->s.sound = 0;
-		self->monsterinfo.currentmove = &jorg_move_end_attack1;	
+		self->monsterinfo.currentmove = &jorg_move_end_attack1;
 	}
 }
 
@@ -453,7 +453,7 @@ void jorg_pain (edict_t *self, edict_t *other, float kick, int damage)
 
 	if (self->health < (self->max_health / 2))
 			self->s.skinnum = 1;
-	
+
 	self->s.sound = 0;
 
 	if (level.time < self->pain_debounce_time)
@@ -464,11 +464,11 @@ void jorg_pain (edict_t *self, edict_t *other, float kick, int damage)
 		if (random()<=0.6)
 			return;
 
-	/* 
+	/*
 	If he's entering his attack1 or using attack1, lessen the chance of him
 	going into pain
 	*/
-	
+
 	if ( (self->s.frame >= FRAME_attak101) && (self->s.frame <= FRAME_attak108) )
 		if (random() <= 0.005)
 			return;
@@ -528,7 +528,7 @@ void jorgBFG (edict_t *self)
 	VectorNormalize (dir);
 	gi.sound (self, CHAN_VOICE, sound_attack2, 1, ATTN_NORM, 0);
         monster_fire_bfg (self, start, dir, 50, 300, 100, 200, MZ2_JORG_BFG_1);
-}	
+}
 
 void jorg_firebullet_right (edict_t *self)
 {
@@ -555,7 +555,7 @@ void jorg_firebullet_right (edict_t *self)
 	}
 
 	monster_fire_bullet (self, start, forward, 6, 4, DEFAULT_BULLET_HSPREAD, DEFAULT_BULLET_VSPREAD, MZ2_JORG_MACHINEGUN_R1);
-}	
+}
 
 void jorg_firebullet_left (edict_t *self)
 {
@@ -582,7 +582,7 @@ void jorg_firebullet_left (edict_t *self)
 	}
 
 	monster_fire_bullet (self, start, forward, 6, 4, DEFAULT_BULLET_HSPREAD, DEFAULT_BULLET_VSPREAD, MZ2_JORG_MACHINEGUN_L1);
-}	
+}
 
 void jorg_firebullet (edict_t *self)
 {
@@ -597,16 +597,10 @@ void jorg_firebullet (edict_t *self)
 
 void jorg_attack(edict_t *self)
 {
-	vec3_t	vec;
-	float	range;
-
 	if (!self)
 	{
 		return;
 	}
-
-	VectorSubtract (self->enemy->s.origin, self->s.origin, vec);
-	range = VectorLength (vec);
 
 	if (random() <= 0.75)
 	{
@@ -647,7 +641,6 @@ qboolean Jorg_CheckAttack (edict_t *self)
 	vec3_t	temp;
 	float	chance;
 	trace_t	tr;
-	qboolean	enemy_infront;
 	int			enemy_range;
 	float		enemy_yaw;
 
@@ -670,8 +663,7 @@ qboolean Jorg_CheckAttack (edict_t *self)
 		if (tr.ent != self->enemy)
 			return false;
 	}
-	
-	enemy_infront = infront(self, self->enemy);
+
 	enemy_range = range(self, self->enemy);
 	VectorSubtract (self->enemy->s.origin, self->s.origin, temp);
 	enemy_yaw = vectoyaw(temp);
@@ -688,14 +680,14 @@ qboolean Jorg_CheckAttack (edict_t *self)
 			self->monsterinfo.attack_state = AS_MISSILE;
 		return true;
 	}
-	
+
 	// missile attack
 	if (!self->monsterinfo.attack)
 		return false;
-		
+
 	if (level.time < self->monsterinfo.attack_finished)
 		return false;
-		
+
 	if (enemy_range == RANGE_FAR)
 		return false;
 
@@ -796,7 +788,7 @@ void SP_monster_jorg (edict_t *self)
 	self->monsterinfo.sight = NULL;
 	self->monsterinfo.checkattack = Jorg_CheckAttack;
 	gi.linkentity (self);
-	
+
 	self->monsterinfo.currentmove = &jorg_move_stand;
 	self->monsterinfo.scale = MODEL_SCALE;
 

--- a/src/monster/boss3/boss32.c
+++ b/src/monster/boss3/boss32.c
@@ -120,7 +120,7 @@ mframe_t makron_frames_stand []=
 	{ai_stand, 0, NULL}		// 60
 };
 mmove_t	makron_move_stand = {FRAME_stand201, FRAME_stand260, makron_frames_stand, NULL};
-	
+
 void makron_stand (edict_t *self)
 {
 	if (!self)
@@ -323,7 +323,7 @@ mframe_t makron_frames_death2 [] =
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
-	{ai_move,	0,	NULL},			
+	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},			// 30
@@ -337,7 +337,6 @@ mframe_t makron_frames_death2 [] =
 	{ai_move,	0,	NULL},
 	{ai_move,	-1,	NULL},
 	{ai_move,	2,	NULL},			// 40
-	{ai_move,	0,	NULL},			
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
@@ -345,9 +344,10 @@ mframe_t makron_frames_death2 [] =
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
-	{ai_move,	0,	NULL},			
+	{ai_move,	0,	NULL},
+	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},			// 50
-	{ai_move,	0,	NULL},			
+	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
 	{ai_move,	-6,	NULL},
@@ -357,7 +357,7 @@ mframe_t makron_frames_death2 [] =
 	{ai_move,	-4,	makron_step_left},
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},			// 60
-	{ai_move,	0,	NULL},			
+	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
 	{ai_move,	-2,	NULL},
 	{ai_move,	-5,	NULL},
@@ -367,7 +367,7 @@ mframe_t makron_frames_death2 [] =
 	{ai_move,	-7,	NULL},
 	{ai_move,	-4,	NULL},
 	{ai_move,	-4,	makron_step_right},			// 70
-	{ai_move,	-6,	NULL},			
+	{ai_move,	-6,	NULL},
 	{ai_move,	-7,	NULL},
 	{ai_move,	0,	makron_step_left},
 	{ai_move,	0,	NULL},
@@ -377,7 +377,7 @@ mframe_t makron_frames_death2 [] =
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},			// 80
-	{ai_move,	0,	NULL},			
+	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
 	{ai_move,	0,	NULL},
@@ -387,7 +387,7 @@ mframe_t makron_frames_death2 [] =
 	{ai_move,	0,	NULL},
 	{ai_move,	2,	NULL},
 	{ai_move,	0,	NULL},			// 90
-	{ai_move,	27,	makron_hit},			
+	{ai_move,	27,	makron_hit},
 	{ai_move,	26,	NULL},
 	{ai_move,	0,	makron_brainsplorch},
 	{ai_move,	0,	NULL},
@@ -465,7 +465,7 @@ void makronBFG (edict_t *self)
 	VectorNormalize (dir);
 	gi.sound (self, CHAN_VOICE, sound_attack_bfg, 1, ATTN_NORM, 0);
 	monster_fire_bfg (self, start, dir, 50, 300, 100, 300, MZ2_MAKRON_BFG);
-}	
+}
 
 
 mframe_t makron_frames_attack3 []=
@@ -558,7 +558,7 @@ void MakronRailgun (edict_t *self)
 
 	AngleVectors (self->s.angles, forward, right, NULL);
 	G_ProjectSource (self->s.origin, monster_flash_offset[MZ2_MAKRON_RAILGUN_1], forward, right, start);
-	
+
 	// calc direction to where we targted
 	VectorSubtract (self->pos1, start, dir);
 	VectorNormalize (dir);
@@ -606,7 +606,7 @@ void MakronHyperblaster (edict_t *self)
 	AngleVectors (dir, forward, NULL, NULL);
 
 	monster_fire_blaster (self, start, forward, 15, 1000, MZ2_MAKRON_BLASTER_1, EF_BLASTER);
-}	
+}
 
 
 void makron_pain (edict_t *self, edict_t *other, float kick, int damage)
@@ -674,8 +674,6 @@ void makron_sight(edict_t *self, edict_t *other)
 
 void makron_attack(edict_t *self)
 {
-	vec3_t	vec;
-	float	range;
 	float	r;
 
 	if (!self)
@@ -684,10 +682,6 @@ void makron_attack(edict_t *self)
 	}
 
 	r = random();
-
-	VectorSubtract (self->enemy->s.origin, self->s.origin, vec);
-	range = VectorLength (vec);
-
 
 	if (r <= 0.3)
 		self->monsterinfo.currentmove = &makron_move_attack3;
@@ -799,7 +793,7 @@ void makron_die (edict_t *self, edict_t *inflictor, edict_t *attacker, int damag
 	makron_torso (tempent);
 
 	self->monsterinfo.currentmove = &makron_move_death2;
-	
+
 }
 
 qboolean Makron_CheckAttack (edict_t *self)
@@ -808,7 +802,6 @@ qboolean Makron_CheckAttack (edict_t *self)
 	vec3_t	temp;
 	float	chance;
 	trace_t	tr;
-	qboolean	enemy_infront;
 	int			enemy_range;
 	float		enemy_yaw;
 
@@ -831,8 +824,7 @@ qboolean Makron_CheckAttack (edict_t *self)
 		if (tr.ent != self->enemy)
 			return false;
 	}
-	
-	enemy_infront = infront(self, self->enemy);
+
 	enemy_range = range(self, self->enemy);
 	VectorSubtract (self->enemy->s.origin, self->s.origin, temp);
 	enemy_yaw = vectoyaw(temp);
@@ -849,14 +841,14 @@ qboolean Makron_CheckAttack (edict_t *self)
 			self->monsterinfo.attack_state = AS_MISSILE;
 		return true;
 	}
-	
+
 	// missile attack
 	if (!self->monsterinfo.attack)
 		return false;
-		
+
 	if (level.time < self->monsterinfo.attack_finished)
 		return false;
-		
+
 	if (enemy_range == RANGE_FAR)
 		return false;
 
@@ -963,7 +955,7 @@ void SP_monster_makron (edict_t *self)
 	self->monsterinfo.checkattack = Makron_CheckAttack;
 
 	gi.linkentity (self);
-	
+
 	self->monsterinfo.currentmove = &makron_move_sight;
 	self->monsterinfo.scale = MODEL_SCALE;
 

--- a/src/player/client.c
+++ b/src/player/client.c
@@ -140,7 +140,7 @@ void SP_info_player_coop(edict_t *self)
 The deathmatch intermission point will be at one of these
 Use 'angles' instead of 'angle', so you can set pitch or roll as well as yaw.  'pitch yaw roll'
 */
-void SP_info_player_intermission(void)
+void SP_info_player_intermission(edict_t *ent)
 {
 }
 
@@ -185,7 +185,7 @@ qboolean IsFemale (edict_t *ent)
 struct monsterObit {
 	char *classname;
 	char *message;
-} obits[] = 
+} obits[] =
 {
 	{"monster_soldier", "%s was slaughtered by a Shotgun Guard.\n"},
 	{"monster_soldier_light", "%s was exterminated by a Light Guard.\n"},
@@ -570,7 +570,7 @@ void player_die (edict_t *self, edict_t *inflictor, edict_t *attacker, int damag
 	{
 		stopCamera(self);
 	}
-	
+
 	VectorClear (self->avelocity);
 
 	self->takedamage = DAMAGE_YES;
@@ -679,7 +679,7 @@ void InitClientPersistant (gclient_t *client)
 
 	item = FindItem("Push");
 	client->pers.inventory[ITEM_INDEX(item)] = 1;
-	
+
 	item = FindItem("Blaster");
 	client->pers.selected_item = ITEM_INDEX(item);
 	client->pers.inventory[client->pers.selected_item] = 1;
@@ -693,7 +693,7 @@ void InitClientPersistant (gclient_t *client)
 		client->pers.inventory[ITEM_INDEX(item)] = 3;
 	}
 
-	
+
 	client->pers.health			      = 100;
 	client->pers.max_health		    = 100;
 
@@ -730,7 +730,7 @@ void InitClientResp (gclient_t *client)
 ==================
 SaveClientData
 
-Some information that should be persistant, like health, 
+Some information that should be persistant, like health,
 is still stored in the edict structure, so it needs to
 be mirrored out to the client structure before all the
 edicts are wiped.
@@ -1249,7 +1249,7 @@ void PutClientInServer (edict_t *ent)
 		char		userinfo[MAX_INFO_STRING];
 
 		int health = client->pers.health;
-		
+
 		memcpy (userinfo, client->pers.userinfo, sizeof(userinfo));
 		InitClientPersistant(client);
 		ClientUserinfoChanged (ent, userinfo);
@@ -1344,7 +1344,7 @@ void PutClientInServer (edict_t *ent)
 =====================
 ClientBeginDeathmatch
 
-A client has just connected to the server in 
+A client has just connected to the server in
 deathmatch mode, so clear everything out before starting them.
 =====================
 */
@@ -1672,7 +1672,7 @@ void ClientThink (edict_t *ent, usercmd_t *ucmd)
 	{
 		client->ps.pmove.pm_type = PM_FREEZE;
 		// can exit intermission after five seconds
-		if (level.time > level.intermissiontime + 5.0 
+		if (level.time > level.intermissiontime + 5.0
 			&& (ucmd->buttons & BUTTON_ANY) )
 			level.exitintermission = true;
 		return;
@@ -1688,7 +1688,7 @@ void ClientThink (edict_t *ent, usercmd_t *ucmd)
 
 	// set up for pmove
 	memset (&pm, 0, sizeof(pm));
-	
+
 	if (ent->movetype == MOVETYPE_NOCLIP)
 		client->ps.pmove.pm_type = PM_SPECTATOR;
 	else if (ent->s.modelindex != 255)

--- a/src/player/hud.c
+++ b/src/player/hud.c
@@ -164,7 +164,6 @@ void DeathmatchScoreboardMessage (edict_t *ent, edict_t *killer)
 	int		sorted[MAX_CLIENTS];
 	int		sortedscores[MAX_CLIENTS];
 	int		score, total;
-	int		picnum;
 	int		x, y;
 	gclient_t	*cl;
 	edict_t		*cl_ent;
@@ -212,7 +211,6 @@ void DeathmatchScoreboardMessage (edict_t *ent, edict_t *killer)
 		cl = &game.clients[sorted[i]];
 		cl_ent = g_edicts + 1 + sorted[i];
 
-		picnum = gi.imageindex ("i_fixme");
 		x = (i>=6) ? 160 : 0;
 		y = 32 + 32 * (i%6);
 
@@ -335,12 +333,12 @@ void HelpComputer (edict_t *ent)
 		"xv 0 yv 54 cstring2 \"%s\" "		// help 1
 		"xv 0 yv 110 cstring2 \"%s\" "		// help 2
 		"xv 50 yv 164 string2 \" kills     goals    secrets\" "
-		"xv 50 yv 172 string2 \"%3i/%3i     %i/%i       %i/%i\" ", 
+		"xv 50 yv 172 string2 \"%3i/%3i     %i/%i       %i/%i\" ",
 		sk,
 		level.level_name,
 		game.helpmessage1,
 		game.helpmessage2,
-		level.killed_monsters, level.total_monsters, 
+		level.killed_monsters, level.total_monsters,
 		level.found_goals, level.total_goals,
 		level.found_secrets, level.total_secrets);
 
@@ -426,9 +424,9 @@ void G_SetStats (edict_t *ent)
 		ent->client->ps.stats[STAT_AMMO_ICON] = gi.imageindex (item->icon);
 		ent->client->ps.stats[STAT_AMMO] = ent->client->pers.inventory[ent->client->ammo_index];
 	}
-	
+
 	cells = 0;
-	
+
 	//
 	// armor
 	//

--- a/src/savegame/tables/gamefunc_decs.h
+++ b/src/savegame/tables/gamefunc_decs.h
@@ -404,7 +404,7 @@ extern void TossClientWeapon ( edict_t * self ) ;
 extern void ClientObituary ( edict_t * self , edict_t * inflictor , edict_t * attacker ) ;
 extern qboolean IsFemale ( edict_t * ent ) ;
 extern void player_pain ( edict_t * self , edict_t * other , float kick , int damage ) ;
-extern void SP_info_player_intermission ( void ) ;
+extern void SP_info_player_intermission ( edict_t *ent ) ;
 extern void SP_info_player_coop ( edict_t * self ) ;
 extern void SP_info_player_deathmatch ( edict_t * self ) ;
 extern void SP_info_player_start ( edict_t * self ) ;


### PR DESCRIPTION
src/g_items.c:2869:6: warning: variable ‘index’ set but not used [-Wunused-but-set-variable]
src/g_phys.c:535:10: warning: variable ‘mins’ set but not used [-Wunused-but-set-variable]
src/g_phys.c:535:16: warning: variable ‘maxs’ set but not used [-Wunused-but-set-variable]
src/g_spawn.c:575:6: warning: variable ‘oldmaxent’ set but not used [-Wunused-but-set-variable]
src/g_target.c:537:6: warning: variable ‘effect’ set but not used [-Wunused-but-set-variable]
src/monster/boss2/boss2.c:564:11: warning: variable ‘enemy_infront’ set but not used [-Wunused-but-set-variable]
src/monster/boss3/boss31.c:601:8: warning: variable ‘range’ set but not used [-Wunused-but-set-variable]
src/monster/boss3/boss31.c:650:11: warning: variable ‘enemy_infront’ set but not used [-Wunused-but-set-variable]
src/monster/boss3/boss32.c:678:8: warning: variable ‘range’ set but not used [-Wunused-but-set-variable]
src/monster/boss3/boss32.c:811:11: warning: variable ‘enemy_infront’ set but not used [-Wunused-but-set-variable]
src/monster/boss/boss.c:797:8: warning: variable ‘length’ set but not used [-Wunused-but-set-variable]
src/player/hud.c:167:7: warning: variable ‘picnum’ set but not used [-Wunused-but-set-variable]