### PR TITLE
Multiple gameplay fixes

### DIFF
--- a/src/g_misc.c
+++ b/src/g_misc.c
@@ -1682,7 +1682,7 @@ void misc_viper_bomb_touch (edict_t *self, edict_t *other, cplane_t *plane, csur
 	G_UseTargets (self, self->activator);
 
 	self->s.origin[2] = self->absmin[2] + 1;
-	T_RadiusDamage (self, self, self->dmg, NULL, self->dmg+40, MOD_BOMB);
+	T_RadiusDamage (self, self, self->dmg, self, self->dmg+40, MOD_BOMB);
 	BecomeExplosion2 (self);
 }
 

--- a/src/g_target.c
+++ b/src/g_target.c
@@ -325,7 +325,7 @@ void target_explosion_explode (edict_t *self)
 		gi.multicast (self->s.origin, MULTICAST_PHS);
 	}
 
-	T_RadiusDamage (self, self->activator, self->dmg, NULL, self->dmg+40, MOD_EXPLOSIVE);
+	T_RadiusDamage (self, self->activator, self->dmg, self, self->dmg+40, MOD_EXPLOSIVE);
 
 	save = self->delay;
 	self->delay = 0;

--- a/src/zaero/item.c
+++ b/src/zaero/item.c
@@ -214,11 +214,6 @@ edict_t *findNextCamera(edict_t *old)
 {
 	edict_t *e = NULL;
 
-	if (!old)
-	{
-		return NULL;
-	}
-
 	// first of all, are there *any* cameras?
 	e = G_Find(NULL, FOFS(classname), "misc_securitycamera");
 	if (e == NULL)

--- a/src/zaero/weapon.c
+++ b/src/zaero/weapon.c
@@ -1,5 +1,6 @@
 #include "../header/local.h"
 #include "../monster/misc/player.h"
+#include <stdio.h>
 
 extern qboolean is_quad;
 extern byte is_silenced;
@@ -116,7 +117,7 @@ void TripBomb_Explode (edict_t *ent)
 		return;
 	}
 
-	T_RadiusDamage(ent, ent->owner ? ent->owner : ent, ent->dmg, ent->enemy, ent->dmg_radius, MOD_TRIPBOMB);
+	T_RadiusDamage(ent, ent->owner ? ent->owner : ent, ent->dmg, ent, ent->dmg_radius, MOD_TRIPBOMB);
 
 	VectorMA (ent->s.origin, -0.02, ent->velocity, origin);
 

--- a/src/zaero/weapon.c
+++ b/src/zaero/weapon.c
@@ -1,6 +1,5 @@
 #include "../header/local.h"
 #include "../monster/misc/player.h"
-#include <stdio.h>
 
 extern qboolean is_quad;
 extern byte is_silenced;


### PR DESCRIPTION
This pull request addresses multiple game play issues. Most of them related to the wrong usage of T_RadiusDamage

- Trip bombs now inflict damage to players and enemies near by and not only the shattered shards spawned upon explosion
- Triggered explosions will now cause damage to their surroundings (if dmg is > 0 of course)
  - This will fix the insane marine not getting killed by the explosion upon re-entering zbase1 from zbase2 to drop the security pass needed to proceed with zbase1 to zbase3
- The viper bomb right at the beginning from zbase1 will now kill the monster tank which will then trigger the removal of the wall next to him.
  - This is necessary because if not killed upon re-entering zbase1 from zbase2 you won't be able to leave the secret room behind that wall.
- Visors now work