### PR TITLE
Added missing include, fixing compilation in Linux and MacOS

### DIFF
--- a/src/player/weapon.c
+++ b/src/player/weapon.c
@@ -2,7 +2,7 @@
 
 #include "../header/local.h"
 #include "../monster/misc/player.h"
-
+#include <limits.h>
 
 qboolean	is_quad;
 byte		is_silenced;


### PR DESCRIPTION
Zaero version of https://github.com/yquake2/yquake2/pull/1059
`limits.h` has to be manually included in Linux and MacOS.