### PR TITLE
Update definitions according to CMakeLists.txt

### DIFF
--- a/src/savegame/savegame.c
+++ b/src/savegame/savegame.c
@@ -61,12 +61,12 @@
  * created on other systems or architectures. This will
  * crash q2 in spectacular ways
  */
-#ifndef YQ2_OSTYPE
-#error YQ2_OSTYPE should be defined by the build system
+#ifndef YQ2OSTYPE
+#error YQ2OSTYPE should be defined by the build system
 #endif
 
-#ifndef YQ2_ARCH
-#error YQ2_ARCH should be defined by the build system
+#ifndef YQ2ARCH
+#error YQ2ARCH should be defined by the build system
 #endif
 
 /*
@@ -74,29 +74,29 @@
  * macros, implemented by savegame version YQ2-1.
  */
 #if defined(__APPLE__)
-#define OSTYPE_1 "MacOS X"
+#define YQ2OSTYPE_1 "MacOS X"
 #elif defined(__FreeBSD__)
-#define OSTYPE_1 "FreeBSD"
+#define YQ2OSTYPE_1 "FreeBSD"
 #elif defined(__OpenBSD__)
-#define OSTYPE_1 "OpenBSD"
+#define YQ2OSTYPE_1 "OpenBSD"
 #elif defined(__linux__)
- #define OSTYPE_1 "Linux"
+ #define YQ2OSTYPE_1 "Linux"
 #elif defined(_WIN32)
- #define OSTYPE_1 "Windows"
+ #define YQ2OSTYPE_1 "Windows"
 #else
- #define OSTYPE_1 "Unknown"
+ #define YQ2OSTYPE_1 "Unknown"
 #endif
 
 #if defined(__i386__)
-#define ARCH_1 "i386"
+#define YQ2ARCH_1 "i386"
 #elif defined(__x86_64__)
-#define ARCH_1 "amd64"
+#define YQ2ARCH_1 "amd64"
 #elif defined(__sparc__)
-#define ARCH_1 "sparc64"
+#define YQ2ARCH_1 "sparc64"
 #elif defined(__ia64__)
- #define ARCH_1 "ia64"
+ #define YQ2ARCH_1 "ia64"
 #else
- #define ARCH_1 "unknown"
+ #define YQ2ARCH_1 "unknown"
 #endif
 
 /*
@@ -771,8 +771,8 @@ WriteGame(const char *filename, qboolean autosave)
 
 	Q_strlcpy(sv.ver, SAVEGAMEVER, sizeof(sv.ver));
 	Q_strlcpy(sv.game, GAMEVERSION, sizeof(sv.game));
-	Q_strlcpy(sv.os, YQ2_OSTYPE, sizeof(sv.os) - 1);
-	Q_strlcpy(sv.arch, YQ2_ARCH, sizeof(sv.arch));
+	Q_strlcpy(sv.os, YQ2OSTYPE, sizeof(sv.os) - 1);
+	Q_strlcpy(sv.arch, YQ2ARCH, sizeof(sv.arch));
 
 	fwrite(&sv, sizeof(sv), 1, f);
 
@@ -846,7 +846,7 @@ ReadGame(const char *filename)
 			fclose(f);
 			gi.error("Savegame from another game.so.\n");
 		}
-		else if (strcmp(sv.os, OSTYPE_1) != 0)
+		else if (strcmp(sv.os, YQ2OSTYPE_1) != 0)
 		{
 			fclose(f);
 			gi.error("Savegame from another os.\n");
@@ -860,7 +860,7 @@ ReadGame(const char *filename)
 			gi.error("Savegame from another architecture.\n");
 		}
 #else
-		if (strcmp(sv.arch, ARCH_1) != 0)
+		if (strcmp(sv.arch, YQ2ARCH_1) != 0)
 		{
 			fclose(f);
 			gi.error("Savegame from another architecture.\n");
@@ -874,16 +874,16 @@ ReadGame(const char *filename)
 			fclose(f);
 			gi.error("Savegame from another game.so.\n");
 		}
-		else if (strcmp(sv.os, YQ2_OSTYPE) != 0)
+		else if (strcmp(sv.os, YQ2OSTYPE) != 0)
 		{
 			fclose(f);
 			gi.error("Savegame from another os.\n");
 		}
-		else if (strcmp(sv.arch, YQ2_ARCH) != 0)
+		else if (strcmp(sv.arch, YQ2ARCH) != 0)
 		{
 #if defined(_WIN32) && (defined(__i386__) || defined(_M_IX86))
 			// before savegame version "YQ2-4" (and after version 1),
-			// the official Win32 binaries accidentally had the YQ2_ARCH "AMD64"
+			// the official Win32 binaries accidentally had the YQ2ARCH "AMD64"
 			// instead of "i386" set due to a bug in the Makefile.
 			// This quirk allows loading those savegames anyway
 			if (save_ver >= 4 || strcmp(sv.arch, "AMD64") != 0)


### PR DESCRIPTION
Unable to build Zaero: update definitions in savegame.c to reflect CMakeLists.txt

Kept naming the same as in xatrix and rogue.

Just noticed that #42 addresses the same issue but changes CMakeLists.txt and Makefile.