### PR TITLE
Updated HUD + weapon commands

### DIFF
--- a/src/g_cmds.c
+++ b/src/g_cmds.c
@@ -738,27 +738,48 @@ void Cmd_WeapPrev_f (edict_t *ent)
 
 	cl = ent->client;
 
-	if (!cl->pers.weapon)
+	if (g_quick_weap->value && cl->newweapon)
+	{
+		it = cl->newweapon;
+	}
+	else if (cl->pers.weapon)
+	{
+		it = cl->pers.weapon;
+	}
+	else
+	{
 		return;
+	}
 
-	selected_weapon = ITEM_INDEX(cl->pers.weapon);
+	selected_weapon = ITEM_INDEX(it);
 
-	// scan  for the next valid one
+	// scan for the next valid one
 	for (i=1 ; i<=MAX_ITEMS ; i++)
 	{
-		index = (selected_weapon + MAX_ITEMS - i)%MAX_ITEMS;
+		index = (selected_weapon + MAX_ITEMS - i) % MAX_ITEMS;
 		if (!cl->pers.inventory[index])
+		{
 			continue;
+		}
+
 		it = &itemlist[index];
-		if (it->hideFlags & HIDE_FROM_SELECTION)
+		if ( (it->hideFlags & HIDE_FROM_SELECTION)
+			|| !it->use || !(it->flags & IT_WEAPON) )
+		{
 			continue;
-		if (!it->use)
-			continue;
-		if (! (it->flags & IT_WEAPON) )
-			continue;
+		}
+
 		it->use (ent, it);
 		if (cl->newweapon == it)
+		{
+			if (g_quick_weap->value)
+			{
+				cl->ps.stats[STAT_PICKUP_ICON] = gi.imageindex(it->icon);
+				cl->ps.stats[STAT_PICKUP_STRING] = CS_ITEMS + ITEM_INDEX(it);
+				cl->pickup_msg_time = level.time + 0.9f;
+			}
 			return;	// successful
+		}
 	}
 }
 
@@ -781,27 +802,48 @@ void Cmd_WeapNext_f (edict_t *ent)
 
 	cl = ent->client;
 
-	if (!cl->pers.weapon)
+	if (g_quick_weap->value && cl->newweapon)
+	{
+		it = cl->newweapon;
+	}
+	else if (cl->pers.weapon)
+	{
+		it = cl->pers.weapon;
+	}
+	else
+	{
 		return;
+	}
 
-	selected_weapon = ITEM_INDEX(cl->pers.weapon);
+	selected_weapon = ITEM_INDEX(it);
 
-	// scan  for the next valid one
+	// scan for the next valid one
 	for (i=1 ; i<=MAX_ITEMS ; i++)
 	{
-		index = (selected_weapon + i)%MAX_ITEMS;
+		index = (selected_weapon + i) % MAX_ITEMS;
 		if (!cl->pers.inventory[index])
+		{
 			continue;
+		}
+
 		it = &itemlist[index];
-		if (it->hideFlags & HIDE_FROM_SELECTION)
+		if ( (it->hideFlags & HIDE_FROM_SELECTION)
+			|| !it->use || !(it->flags & IT_WEAPON) )
+		{
 			continue;
-		if (!it->use)
-			continue;
-		if (! (it->flags & IT_WEAPON) )
-			continue;
+		}
+
 		it->use (ent, it);
 		if (cl->newweapon == it)
+		{
+			if (g_quick_weap->value)
+			{
+				cl->ps.stats[STAT_PICKUP_ICON] = gi.imageindex(it->icon);
+				cl->ps.stats[STAT_PICKUP_STRING] = CS_ITEMS + ITEM_INDEX(it);
+				cl->pickup_msg_time = level.time + 0.9f;
+			}
 			return;	// successful
+		}
 	}
 }
 

--- a/src/g_cmds.c
+++ b/src/g_cmds.c
@@ -1272,29 +1272,37 @@ static void
 Cmd_CycleWeap_f(edict_t *ent)
 {
 	gitem_t *weap;
+	gclient_t *cl;
+	int num_weaps;
 
 	if (!ent)
 	{
 		return;
 	}
 
-	if (gi.argc() <= 1)
+	num_weaps = gi.argc();
+	if (num_weaps <= 1)
 	{
 		gi.cprintf(ent, PRINT_HIGH, "Usage: cycleweap classname1 classname2 .. classnameN\n");
 		return;
 	}
 
 	weap = cycle_weapon(ent);
-	if (weap)
+	if (!weap) return;
+
+	cl = ent->client;
+	if (cl->pers.inventory[ITEM_INDEX(weap)] <= 0)
 	{
-		if (ent->client->pers.inventory[ITEM_INDEX(weap)] <= 0)
-		{
-			gi.cprintf(ent, PRINT_HIGH, "Out of item: %s\n", weap->pickup_name);
-		}
-		else
-		{
-			weap->use(ent, weap);
-		}
+		gi.cprintf(ent, PRINT_HIGH, "Out of item: %s\n", weap->pickup_name);
+		return;
+	}
+
+	weap->use(ent, weap);
+	if (num_weaps > 3 && cl->newweapon == weap)
+	{
+		cl->ps.stats[STAT_PICKUP_ICON] = gi.imageindex(weap->icon);
+		cl->ps.stats[STAT_PICKUP_STRING] = CS_ITEMS + ITEM_INDEX(weap);
+		cl->pickup_msg_time = level.time + 0.7f;
 	}
 }
 

--- a/src/g_main.c
+++ b/src/g_main.c
@@ -47,6 +47,7 @@ cvar_t	*sv_cheats;
 
 cvar_t *aimfix;
 cvar_t *g_machinegun_norecoil;
+cvar_t *g_quick_weap;
 cvar_t *g_swap_speed;
 
 void SpawnEntities (char *mapname, char *entities, char *spawnpoint);

--- a/src/header/local.h
+++ b/src/header/local.h
@@ -611,6 +611,7 @@ extern	cvar_t	*bettyammo;
 
 extern cvar_t *aimfix;
 extern cvar_t *g_machinegun_norecoil;
+extern cvar_t *g_quick_weap;
 extern cvar_t *g_swap_speed;
 
 #define world	(&g_edicts[0])

--- a/src/player/hud.c
+++ b/src/player/hud.c
@@ -547,13 +547,29 @@ void G_SetStats (edict_t *ent)
 	//
 	// help icon / current weapon if not shown
 	//
-	if (ent->client->resp.helpchanged && (level.framenum&8) )
+	if (ent->client->resp.helpchanged && (level.framenum & 8) )
+	{
 		ent->client->ps.stats[STAT_HELPICON] = gi.imageindex ("i_help");
+	}
 	else if ( (ent->client->pers.hand == CENTER_HANDED || ent->client->ps.fov > 91)
 		&& ent->client->pers.weapon)
-		ent->client->ps.stats[STAT_HELPICON] = gi.imageindex (ent->client->pers.weapon->icon);
+	{
+		cvar_t *gun = gi.cvar("cl_gun", "2", 0);
+
+		if (gun->value != 2)
+		{
+			ent->client->ps.stats[STAT_HELPICON] = gi.imageindex(
+					ent->client->pers.weapon->icon);
+		}
+		else
+		{
+			ent->client->ps.stats[STAT_HELPICON] = 0;
+		}
+	}
 	else
+	{
 		ent->client->ps.stats[STAT_HELPICON] = 0;
+	}
 
 	// origin
 	if (ent->client->showOrigin)

--- a/src/savegame/savegame.c
+++ b/src/savegame/savegame.c
@@ -237,6 +237,7 @@ InitGame(void)
 	/* others */
 	aimfix = gi.cvar("aimfix", "0", CVAR_ARCHIVE);
 	g_machinegun_norecoil = gi.cvar("g_machinegun_norecoil", "0", CVAR_ARCHIVE);
+	g_quick_weap = gi.cvar("g_quick_weap", "1", CVAR_ARCHIVE);
 	g_swap_speed = gi.cvar("g_swap_speed", "1", CVAR_ARCHIVE);
 
 	/* items */


### PR DESCRIPTION
_Zaero_ versions of:

- yquake2/yquake2@bcdd802ec
If `cl_gun 2`, don't show the gun icon, no matter the `fov` or `hand` values.
Maybe only @DanielGibson cares about this, but I wanted to have consistency between projects.

- yquake2/yquake2#1076
Allows to skip the "previous" or "next" weapon, by constantly tapping the bound key (or scrolling the mouse wheel).
Shows a preview of upcoming weapon in "pickup" format.

- yquake2/yquake2#1170
Same preview just mentioned, this time applied to `cycleweap`.
Only works when `cycleweap` is called with 3 or more parameters.