### PR TITLE
Fixed splash damage of explosions being broken

### DIFF
--- a/src/g_combat.c
+++ b/src/g_combat.c
@@ -613,7 +613,7 @@ void T_RadiusDamage (edict_t *inflictor, edict_t *attacker, float damage, edict_
 	vec3_t	dir;
 
 
-	if (!inflictor || !attacker || !ignore)
+	if (!inflictor || !attacker)
 	{
 		return;
 	}


### PR DESCRIPTION
I spotted issue https://github.com/yquake2/zaero/issues/24 and it took me less than 5 minutes to see the problem. The excessive `NULL` pointer check strikes again.

Also @Yamagi, you can close issues #29 and #41 as completed.