### PR TITLE
Fixed multiplayer crashing on map load

### DIFF
--- a/src/savegame/savegame.c
+++ b/src/savegame/savegame.c
@@ -253,6 +253,7 @@ InitGame(void)
 
 	/* change anytime vars */
 	dmflags = gi.cvar ("dmflags", "0", CVAR_SERVERINFO);
+	zdmflags = gi.cvar ("zdmflags", "0", CVAR_SERVERINFO);
 	fraglimit = gi.cvar ("fraglimit", "0", CVAR_SERVERINFO);
 	timelimit = gi.cvar ("timelimit", "0", CVAR_SERVERINFO);
 	password = gi.cvar ("password", "", CVAR_USERINFO);


### PR DESCRIPTION
This PR fixes issue https://github.com/yquake2/zaero/issues/4.

The `zdmflags` cvar was never being initialized, so dereferencing it with `zdmflags->value` was crashing the game.