### PR TITLE
savegame: Remove null entries at end of functionList and mmoveList

### DIFF
--- a/src/savegame/tables/gamefunc_list.h
+++ b/src/savegame/tables/gamefunc_list.h
@@ -1266,4 +1266,3 @@
 {"ai_stand", (byte *)ai_stand},
 {"ai_move", (byte *)ai_move},
 {"AI_SetSightClient", (byte *)AI_SetSightClient},
-{0, 0}

--- a/src/savegame/tables/gamemmove_list.h
+++ b/src/savegame/tables/gamemmove_list.h
@@ -355,4 +355,3 @@
 {"actor_move_run", &actor_move_run},
 {"actor_move_walk", &actor_move_walk},
 {"actor_move_stand", &actor_move_stand},
-{0, 0}


### PR DESCRIPTION
A small patch for the recent savegame refactor. The null entries at the end of `functionList` and `mmoveList` are no longer needed and would crash the game if the desired entry is not in the list