### PR TITLE
game: Fixed Z_RadiusDamage and T_RadiusDamagePosition returning early if ignore is NULL

### DIFF
--- a/src/g_combat.c
+++ b/src/g_combat.c
@@ -789,8 +789,7 @@ void T_RadiusDamagePosition (vec3_t origin, edict_t *inflictor, edict_t *attacke
 	vec3_t	v;
 	vec3_t	dir;
 
-
-	if (!inflictor || !ignore)
+	if (!inflictor || !attacker)
 	{
 		return;
 	}

--- a/src/zaero/weapon.c
+++ b/src/zaero/weapon.c
@@ -1329,7 +1329,7 @@ void Z_RadiusDamageVisible(edict_t *inflictor, edict_t *attacker, float damage, 
 	vec3_t	v;
 	vec3_t	dir;
 
-	if (!inflictor || !attacker || !ignore)
+	if (!inflictor || !attacker)
 	{
 		return;
 	}


### PR DESCRIPTION
Fixes https://github.com/yquake2/zaero/issues/24

This PR is a continuation of PR https://github.com/yquake2/zaero/pull/51. The A2K weapon damage should now work as intended, if nothing else was missed.