### PR TITLE
game: Improved robustness and a bit of refactoring in physics code

### DIFF
--- a/src/g_phys.c
+++ b/src/g_phys.c
@@ -22,17 +22,10 @@ walking monsters are SOLID_SLIDEBOX and MOVETYPE_STEP
 flying/floating monsters are SOLID_SLIDEBOX and MOVETYPE_FLY
 
 solid_edge items only clip against bsp models.
-
 */
 
-
-/*
-============
-SV_TestEntityPosition
-
-============
-*/
-edict_t	*SV_TestEntityPosition (edict_t *ent)
+static edict_t *
+SV_TestEntityPosition (edict_t *ent)
 {
 	trace_t	trace;
 	int		mask;
@@ -58,13 +51,8 @@ edict_t	*SV_TestEntityPosition (edict_t *ent)
 	return NULL;
 }
 
-
-/*
-================
-SV_CheckVelocity
-================
-*/
-void SV_CheckVelocity (edict_t *ent)
+static void
+SV_CheckVelocity (edict_t *ent)
 {
 	int		i;
 
@@ -92,7 +80,8 @@ SV_RunThink
 Runs thinking code for this frame if necessary
 =============
 */
-qboolean SV_RunThink (edict_t *ent)
+static qboolean
+SV_RunThink (edict_t *ent)
 {
 	float	thinktime;
 
@@ -121,7 +110,8 @@ SV_Impact
 Two entities have touched, so run their touch functions
 ==================
 */
-void SV_Impact (edict_t *e1, trace_t *trace)
+static void
+SV_Impact(edict_t *e1, trace_t *trace)
 {
 	edict_t		*e2;
 	// cplane_t	backplane;
@@ -349,7 +339,7 @@ SV_AddGravity(edict_t *ent)
  * This leads to a lot of false block tests in SV_Push
  * if another bmodel is in the vicinity.
  */
-void
+static void
 RealBoundingBox(edict_t *ent, vec3_t mins, vec3_t maxs)
 {
 	vec3_t forward, left, up, f1, l1, u1;
@@ -475,7 +465,8 @@ SV_PushEntity
 Does not change the entities velocity at all
 ============
 */
-trace_t SV_PushEntity (edict_t *ent, vec3_t push)
+static trace_t
+SV_PushEntity(edict_t *ent, vec3_t push)
 {
 	trace_t	trace;
 	vec3_t	start;
@@ -525,7 +516,9 @@ retry:
 	return trace;
 }
 
-
+/*
+ * Pushed API
+ */
 typedef struct
 {
 	edict_t	*ent;
@@ -533,11 +526,79 @@ typedef struct
 	vec3_t	angles;
 	float	deltayaw;
 } pushed_t;
-pushed_t	pushed[MAX_EDICTS], *pushed_p;
 
-edict_t	*obstacle;
+static pushed_t	pushed[MAX_EDICTS], *pushed_p;
 
-void adjustRiders(edict_t *ent);
+static void
+Pushed_Init(void)
+{
+	pushed_p = pushed;
+}
+
+static qboolean
+Pushed_Append(edict_t *e)
+{
+	if (pushed_p >= ARREND(pushed))
+	{
+		return false;
+	}
+
+	pushed_p->ent = e;
+	VectorCopy (e->s.origin, pushed_p->origin);
+	VectorCopy (e->s.angles, pushed_p->angles);
+
+	if (e->client)
+		pushed_p->deltayaw = e->client->ps.pmove.delta_angles[YAW];
+
+	pushed_p++;
+
+	return true;
+}
+
+static void
+Pushed_Pop(void)
+{
+	if (pushed_p > pushed)
+	{
+		pushed_p--;
+	}
+}
+
+static void
+Pushed_Undo(void)
+{
+	pushed_t *p;
+
+	// go backwards, so if the same entity was pushed
+	// twice, it goes back to the original position
+	for (p = pushed_p - 1; p >= pushed; p--)
+	{
+		edict_t *e = p->ent;
+
+		VectorCopy (p->origin, e->s.origin);
+		VectorCopy (p->angles, e->s.angles);
+
+		if (e->client)
+		{
+			e->client->ps.pmove.delta_angles[YAW] = p->deltayaw;
+		}
+
+		gi.linkentity (e);
+	}
+
+	pushed_p = pushed;
+}
+
+static void
+Pushed_TouchTriggers(void)
+{
+	pushed_t *p;
+
+	for (p = pushed_p - 1; p >= pushed; p--)
+	{
+		G_TouchTriggers(p->ent);
+	}
+}
 
 /*
 ============
@@ -547,19 +608,19 @@ Objects need to be moved back on a failed push,
 otherwise riders would continue to slide.
 ============
 */
-qboolean
+void adjustRiders(edict_t *ent);
+
+static edict_t *
 SV_Push(edict_t *pusher, vec3_t move, vec3_t amove)
 {
-	int			i, e;
+	int			i;
 	edict_t		*check;
-	const edict_t *block;
-	pushed_t	*p;
-	vec3_t		org, org2, move2, forward, right, up;
+	vec3_t		org, forward, right, up;
 	vec3_t		realmins, realmaxs;
 
 	if (!pusher)
 	{
-		return false;
+		return NULL;
 	}
 
 	// clamp the move to 1/8 units, so the position will
@@ -579,15 +640,11 @@ SV_Push(edict_t *pusher, vec3_t move, vec3_t amove)
 	VectorSubtract(vec3_origin, amove, org);
 	AngleVectors(org, forward, right, up);
 
-	// save the pusher's original position
-	pushed_p->ent = pusher;
-	VectorCopy(pusher->s.origin, pushed_p->origin);
-	VectorCopy(pusher->s.angles, pushed_p->angles);
-	if (pusher->client)
-		pushed_p->deltayaw = pusher->client->ps.pmove.delta_angles[YAW];
-	pushed_p++;
+	if (!Pushed_Append(pusher))
+	{
+		return NULL;
+	}
 
-	// move the pusher to it's final position
 	VectorAdd(pusher->s.origin, move, pusher->s.origin);
 	VectorAdd(pusher->s.angles, amove, pusher->s.angles);
 	gi.linkentity(pusher);
@@ -597,8 +654,7 @@ SV_Push(edict_t *pusher, vec3_t move, vec3_t amove)
 	RealBoundingBox(pusher,realmins,realmaxs);
 
 	// see if any solid entities are inside the final position
-	check = g_edicts+1;
-	for (e = 1; e < globals.num_edicts; e++, check++)
+	for (check = g_edicts + 1; check < &g_edicts[globals.num_edicts]; check++)
 	{
 		if (!check->inuse)
 			continue;
@@ -631,11 +687,12 @@ SV_Push(edict_t *pusher, vec3_t move, vec3_t amove)
 
 		if ((pusher->movetype == MOVETYPE_PUSH) || (check->groundentity == pusher))
 		{
-			// move this entity
-			pushed_p->ent = check;
-			VectorCopy(check->s.origin, pushed_p->origin);
-			VectorCopy(check->s.angles, pushed_p->angles);
-			pushed_p++;
+			vec3_t org2, move2;
+
+			if (!Pushed_Append(check))
+			{
+				continue;
+			}
 
 			// try moving the contacted entity
 			VectorAdd(check->s.origin, move, check->s.origin);
@@ -656,51 +713,34 @@ SV_Push(edict_t *pusher, vec3_t move, vec3_t amove)
 			if (check->groundentity != pusher)
 				check->groundentity = NULL;
 
-			block = SV_TestEntityPosition (check);
-			if (!block)
-			{	// pushed ok
-				gi.linkentity(check);
+			if (!SV_TestEntityPosition (check))
+			{
+				gi.linkentity (check);
 				adjustRiders(check);
-				// impact?
 				continue;
 			}
 
 			// if it is ok to leave in the old position, do it
 			// this is only relevent for riding entities, not pushed
 			// FIXME: this doesn't acount for rotation
+
 			VectorSubtract(check->s.origin, move, check->s.origin);
-			block = SV_TestEntityPosition (check);
-			if (!block)
+
+			if (!SV_TestEntityPosition (check))
 			{
-				pushed_p--;
+				Pushed_Pop();
 				continue;
 			}
 		}
 
-		// save off the obstacle so we can call the block function
-		obstacle = check;
+		Pushed_Undo();
 
-		// move back any entities we already moved
-		// go backwards, so if the same entity was pushed
-		// twice, it goes back to the original position
-		for (p=pushed_p-1 ; p>=pushed ; p--)
-		{
-			VectorCopy(p->origin, p->ent->s.origin);
-			VectorCopy(p->angles, p->ent->s.angles);
-			if (p->ent->client)
-			{
-				p->ent->client->ps.pmove.delta_angles[YAW] = p->deltayaw;
-			}
-			gi.linkentity(p->ent);
-		}
-		return false;
+		return check;
 	}
 
-	// see if anything we moved has touched a trigger
-	for (p=pushed_p-1 ; p>=pushed ; p--)
-		G_TouchTriggers (p->ent);
+	Pushed_TouchTriggers();
 
-	return true;
+	return NULL;
 }
 
 /*
@@ -711,10 +751,10 @@ Bmodel objects don't interact with each other, but
 push all box objects
 ================
 */
-void SV_Physics_Pusher (edict_t *ent)
+static void
+SV_Physics_Pusher(edict_t *ent)
 {
-	vec3_t		move, amove;
-	edict_t		*part, *mv;
+	edict_t *part, *obstacle;
 
 	if (!ent)
 	{
@@ -725,46 +765,46 @@ void SV_Physics_Pusher (edict_t *ent)
 	if ( ent->flags & FL_TEAMSLAVE)
 		return;
 
+	Pushed_Init();
+	obstacle = NULL;
+
 	// make sure all team slaves can move before commiting
 	// any moves or calling any think functions
 	// if the move is blocked, all moved objects will be backed out
-	pushed_p = pushed;
-	for (part = ent ; part ; part=part->teamchain)
+	for (part = ent; part; part = part->teamchain)
 	{
-		if (part->velocity[0] || part->velocity[1] || part->velocity[2] ||
-			part->avelocity[0] || part->avelocity[1] || part->avelocity[2]
-		)
-		{	// object is moving
-			VectorScale(part->velocity, FRAMETIME, move);
-			VectorScale(part->avelocity, FRAMETIME, amove);
+		vec3_t move, amove;
 
-			if (!SV_Push (part, move, amove))
-				break;	// move was blocked
+		if (VectorCompare(part->velocity, vec3_origin) &&
+			VectorCompare(part->avelocity, vec3_origin))
+		{
+			continue;
 		}
-	}
-	if (pushed_p > &pushed[MAX_EDICTS-1])
-	{
-		gi.error (ERR_FATAL, "pushed_p > &pushed[MAX_EDICTS-1], memory corrupted");
+
+		VectorScale(part->velocity, FRAMETIME, move);
+		VectorScale(part->avelocity, FRAMETIME, amove);
+
+		obstacle = SV_Push(part, move, amove);
+		if (obstacle)
+			break;
 	}
 
-	if (part)
+	if (part) /* move failed */
 	{
-		// the move failed, bump all nextthink times and back out moves
-		for (mv = ent ; mv ; mv=mv->teamchain)
+		edict_t *mv;
+
+		for (mv = ent; mv; mv = mv->teamchain)
 		{
 			if (mv->nextthink > 0)
 				mv->nextthink += FRAMETIME;
 		}
 
-		// if the pusher has a "blocked" function, call it
-		// otherwise, just stay in place until the obstacle is gone
 		if (part->blocked)
 			part->blocked (part, obstacle);
 	}
 	else
 	{
-		// the move succeeded, so call all think functions
-		for (part = ent ; part ; part=part->teamchain)
+		for (part = ent; part; part = part->teamchain)
 		{
 			SV_RunThink (part);
 		}
@@ -784,7 +824,6 @@ SV_Physics_None(edict_t *ent)
 		return;
 	}
 
-	/* regular thinking */
 	SV_RunThink(ent);
 }
 
@@ -799,7 +838,6 @@ SV_Physics_Noclip(edict_t *ent)
 		return;
 	}
 
-	/* regular thinking */
 	if (!SV_RunThink(ent))
 	{
 		return;
@@ -826,7 +864,8 @@ SV_Physics_Toss
 Toss, bounce, and fly movement.  When onground, do nothing.
 =============
 */
-void SV_Physics_Toss (edict_t *ent)
+static void
+SV_Physics_Toss(edict_t *ent)
 {
 	trace_t		trace;
 	vec3_t		move;
@@ -840,7 +879,6 @@ void SV_Physics_Toss (edict_t *ent)
 		return;
 	}
 
-	// regular thinking
 	SV_RunThink (ent);
 
 	/* entities are very often freed during thinking */
@@ -974,7 +1012,8 @@ FIXME: is this true?
 #define sv_friction			6
 #define sv_waterfriction	1
 
-void SV_AddRotationalFriction (edict_t *ent)
+static void
+SV_AddRotationalFriction(edict_t *ent)
 {
 	int		n;
 	float	adjustment;
@@ -1003,7 +1042,8 @@ void SV_AddRotationalFriction (edict_t *ent)
 	}
 }
 
-void SV_Physics_Step (edict_t *ent)
+static void
+SV_Physics_Step(edict_t *ent)
 {
 	qboolean	wasonground;
 	qboolean	hitsound = false;
@@ -1118,11 +1158,11 @@ void SV_Physics_Step (edict_t *ent)
 					gi.sound(ent, 0, gi.soundindex("world/land.wav"), 1, 1, 0);
 	}
 
-	// regular thinking
 	SV_RunThink (ent);
 }
 
-void SV_Physics_FallFloat (edict_t *ent)
+static void
+SV_Physics_FallFloat(edict_t *ent)
 {
 	float gravVal;
 	qboolean wasonground = false;
@@ -1257,14 +1297,13 @@ void SV_Physics_FallFloat (edict_t *ent)
 			gi.positioned_sound (ent->s.origin, g_edicts, CHAN_AUTO, gi.soundindex("misc/h2ohit1.wav"), 1, 1, 0);
 	}
 
-	// relink
 	gi.linkentity(ent);
 
-	// regular thinking
 	SV_RunThink (ent);
 }
 
-void adjustRiders(edict_t *ent)
+void
+adjustRiders(edict_t *ent)
 {
 	int i = 0;
 
@@ -1281,7 +1320,8 @@ void adjustRiders(edict_t *ent)
 	}
 }
 
-void SV_Physics_Ride (edict_t *ent)
+static void
+SV_Physics_Ride(edict_t *ent)
 {
 	if (!ent)
 	{
@@ -1294,14 +1334,8 @@ void SV_Physics_Ride (edict_t *ent)
 	adjustRiders(ent);
 }
 
-//============================================================================
-/*
-================
-G_RunEntity
-
-================
-*/
-void G_RunEntity (edict_t *ent)
+void
+G_RunEntity(edict_t *ent)
 {
 	if (!ent)
 	{

--- a/src/g_phys.c
+++ b/src/g_phys.c
@@ -1340,7 +1340,11 @@ void G_RunEntity (edict_t *ent)
 			SV_Physics_Ride(ent);
 			break;
 		default:
-			gi.error ("SV_Physics: bad movetype %i", (int)ent->movetype);
+			gi.dprintf("%s:%d has bad movetype: %d\n",
+				ent->classname, ent->s.number, ent->movetype);
+			ent->movetype = MOVETYPE_NONE;
+			SV_Physics_None(ent);
+			break;
 	}
 }
 

--- a/src/g_phys.c
+++ b/src/g_phys.c
@@ -524,7 +524,6 @@ typedef struct
 	edict_t	*ent;
 	vec3_t	origin;
 	vec3_t	angles;
-	float	deltayaw;
 } pushed_t;
 
 static pushed_t	pushed[MAX_EDICTS], *pushed_p;
@@ -546,9 +545,6 @@ Pushed_Append(edict_t *e)
 	pushed_p->ent = e;
 	VectorCopy (e->s.origin, pushed_p->origin);
 	VectorCopy (e->s.angles, pushed_p->angles);
-
-	if (e->client)
-		pushed_p->deltayaw = e->client->ps.pmove.delta_angles[YAW];
 
 	pushed_p++;
 
@@ -577,11 +573,6 @@ Pushed_Undo(void)
 
 		VectorCopy (p->origin, e->s.origin);
 		VectorCopy (p->angles, e->s.angles);
-
-		if (e->client)
-		{
-			e->client->ps.pmove.delta_angles[YAW] = p->deltayaw;
-		}
 
 		gi.linkentity (e);
 	}


### PR DESCRIPTION
Zaero version of PR https://github.com/yquake2/yquake2/pull/1324

Additionally this PR fixes the legacy issue where player yaw gets thrown around when hurt by a moving brush. This issue was already fixed in YQ2, Xatrix and Rogue.